### PR TITLE
validation custom pour les messages

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,13 +2,16 @@ class Message < ApplicationRecord
   belongs_to :user
   belongs_to :contact
 
-  # contenu obligatoire, min 1, max 2000
-  validates :content, presence: true, length: { minimum: 1, maximum: 2000 }
-
-  # conditions similaires pour la suggestion IA et la réponse utilisateur mais elles ne sont pas obligatoires
-  # Allow blank est en true sinon on ne peut pas créer un message avec juste un contenu envoyé par le contact...
+  # contenu taille min 1, max 2000
+  # conditions similaires pour la suggestion IA et la réponse utilisateur
+  # Allow blank est en true car aucun champ n'est obligatoire mais il faudra un des trois pour que le message soit créé
+  validates :content, length: { minimum: 1, maximum: 2000 }, allow_blank: true
   validates :ai_draft, length: { minimum: 1, maximum: 2000 }, allow_blank: true
   validates :user_answer, length: { minimum: 1, maximum: 2000 }, allow_blank: true
+
+  # Validation perso pour être sûrs qu'au moins un champ entre content, ai_draft et user_answer soit rempli pour
+  # pouvoir créer un message
+  validate :content_or_ai_draft_or_user_answer_present
 
   # Date d’envoi optionnelle, pas dans le futur, peut être blanc
   validates :sent_at, allow_blank: true, comparison: { less_than_or_equal_to: Date.today }
@@ -19,6 +22,15 @@ class Message < ApplicationRecord
   # enum statut (workflow IA suggestion)
   # received == message reçu du contact, contenu stocké dans la colonne content
   # draft_by_ai == suggestion par IA faite et stockée dans la colonne ai_draft
-  # sent == réponse de l'utilisateur envoyée au contact et stockée dans la colonne user_answer
+  # sent == réponse de l'utilisateur envoyée au contact
   enum status: { received: 0, draft_by_ai: 1, sent: 2 }
+
+  private
+
+  # On vérifie qu'au moins un champ soit rempli sinon erreur
+  def content_or_ai_draft_or_user_answer_present
+    if [content, ai_draft, user_answer].all?(&:blank?)
+      errors.add(:base, "Content, or AI Draft or User answer must be filled" )
+    end
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -22,7 +22,7 @@ class Message < ApplicationRecord
   # enum statut (workflow IA suggestion)
   # received == message reçu du contact, contenu stocké dans la colonne content
   # draft_by_ai == suggestion par IA faite et stockée dans la colonne ai_draft
-  # sent == réponse de l'utilisateur envoyée au contact
+  # sent == réponse de l'utilisateur envoyée au contact et stockée dans la colonne user_answer
   enum status: { received: 0, draft_by_ai: 1, sent: 2 }
 
   private
@@ -30,7 +30,7 @@ class Message < ApplicationRecord
   # On vérifie qu'au moins un champ soit rempli sinon erreur
   def content_or_ai_draft_or_user_answer_present
     if [content, ai_draft, user_answer].all?(&:blank?)
-      errors.add(:base, "Content, or AI Draft or User answer must be filled" )
+      errors.add(:base, "Please provide content, an AI draft, or a user answer." )
     end
   end
 end


### PR DESCRIPTION
Validations custom pour les messages : un des trois champ entre content, ai_draft, user_answer doit être rempli pour créer un message.
Différence par rapport à avant : on exigeait un content du contact mais cela ne marchera pas pour les message de "relance" (on peut relancer une conversation alors que le dernier message a été envoyé par nous même et donc le message n'aura pas de content mais juste une user_answer)