### PR TITLE
Documentation domaine et SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Rails app generated with [lewagon/rails-templates](https://github.com/lewagon/rails-templates), created by the [Le Wagon coding bootcamp](https://www.lewagon.com) team.
 # Ce projet utilise du code sous licence MIT.
+
+Le domaine `www.rekonect.space` est connecté à l'app Heroku via un CNAME :
+`current-mouse-213zaq4vjsjh3a1ruoo2tgx6.herokudns.com.`
+
+Certificat SSL validé via Heroku Automatic Certificate Management.
+
+Dernier test : ✅ fonctionne sur Safari, Chrome, Firefox


### PR DESCRIPTION
Ajout d’une section dans le README concernant la configuration du domaine personnalisé et du certificat SSL Heroku.