### PR TITLE
fix(navbar): bouton déconnexion renvoie bien vers la page goodbye + a…

### DIFF
--- a/app/views/shared/_navbar_bottom.html.erb
+++ b/app/views/shared/_navbar_bottom.html.erb
@@ -20,7 +20,7 @@
     <% end %>
   </div>
   <div class="nav-item">
-    <%= link_to root_path do %>
+    <%= link_to goodbye_path do %>
       <i class="bi bi-box-arrow-right"></i>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   get 'users/settings'
   devise_for :users
-  root to: "pages#home"
+  get "/goodbye", to: "pages#home", as: :goodbye
+  root to: "dashboard#index"
   get "messages/awaiting_answer", to: "messages#awaiting_answer", as: :awaiting_answer_messages
   resources :messages do
     member do


### PR DESCRIPTION
correction du lien de déconnexion dans la navbar pour pointer vers goodbye_path au lieu de root_path
ajout de la route GET '/goodbye' vers pages#home
