### PR TITLE
feat(messages): refonte UI page reply + historique des échanges

### DIFF
--- a/app/assets/stylesheets/pages/_messages.scss
+++ b/app/assets/stylesheets/pages/_messages.scss
@@ -17,3 +17,129 @@
   color: $gray-txt;
   font-size: 16px;
 }
+
+// header arrondi
+.reply-header {
+  background: $pink-header;
+  border-radius: 30px;
+  padding: 18px 22px 14px 22px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 auto 18px auto;
+  max-width: 440px;
+}
+
+.reply-title {
+  font-family: $headers-font;
+  font-size: 1.46rem;
+  font-weight: 800;
+  color: #222;
+  margin: 0;
+  line-height: 1.15;
+}
+
+.reply-avatar-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-left: 15px;
+}
+.reply-contact-name {
+  font-size: 1.11rem;
+  font-weight: 700;
+  color: $gray-txt;
+  margin-top: 2px;
+  text-align: center;
+}
+
+// Card pink
+.msg-bubble-pink {
+  background: $pink-header;
+  border-radius: 28px;
+  box-shadow: 0 4px 18px $card-shadow;
+  padding: 18px 14px 14px 14px;
+  max-width: 450px;
+  margin: 0 auto 24px auto;
+}
+
+.reply-block-title {
+  text-align: center;
+  font-size: 1.09rem;
+  color: #222;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.msg-inner-bubble {
+  background: $white;
+  border-radius: 19px;
+  box-shadow: 0 2px 8px $card-shadow;
+  padding: 18px 16px 14px 18px;
+  margin: 12px auto 14px auto;
+  max-width: 98%;
+  min-width: 70px;
+  font-size: 1.06rem;
+}
+
+.message-content {
+  color: #222;
+  font-size: 1.03rem;
+  font-weight: 700;
+}
+
+.message-date {
+  color: $gray-txt;
+  font-size: 0.96rem;
+  font-weight: 500;
+  margin-top: 8px;
+}
+
+// Boutons envoyer et éditer
+.reply-btn-row {
+  display: flex;
+  justify-content: center;
+  gap: 28px;
+  margin: 18px 0 0 0;
+
+  > * {
+    flex: 1 1 0;
+    min-width: 0;
+    max-width: 170px;
+    display: flex !important;
+  }
+}
+
+.reply-btn {
+  width: 100% !important;
+  min-width: 120px;
+  max-width: 170px;
+  font-size: 1.19rem !important;
+  border-radius: 18px !important;
+  margin: 0;
+  box-shadow: 0 4px 16px $card-shadow;
+  font-weight: 700;
+  padding: 12px 0 !important;
+  transition: transform 0.13s;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+  display: flex !important;
+}
+
+// Responsive
+@media (max-width: 480px) {
+  .reply-header, .msg-bubble-pink {
+    max-width: 98vw;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+  .msg-inner-bubble {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+  .reply-btn {
+    width: 48%;
+    font-size: 1rem !important;
+  }
+}

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -44,4 +44,8 @@ class MessagePolicy < ApplicationPolicy
   def rekonect?
     true
   end
+
+  def send_message?
+  true
+  end
 end

--- a/app/views/messages/reply.html.erb
+++ b/app/views/messages/reply.html.erb
@@ -1,19 +1,50 @@
-<div class="dashboard-header">
-  <h1>Prends donc un peu de temps pour <%= @message.contact.name %></h1>
-  <p class="dashboard-welcome">Voici un résumé de vos derniers échanges</p>
+<div class="reply-header">
+  <div>
+  <h1 class="reply-title">Prends donc un peu de temps pour : </h1>
+  </div>
+  <div class="reply-avatar-block">
+  <% if @message.contact.photo.attached? %>
+  <%= image_tag @message.contact.photo.variant(resize_to_fill: [38, 38]), class: "avatar-mobile ms-2" %>
+   <% else %>
+      <%= image_tag "default-avatar.png", class: "avatar-mobile" %>
+    <% end %>
+    <span class="reply-contact-name"><%= @message.contact.name %></span>
+  </div>
 </div>
 
-<div class="card-mobile mb-2">
-    <div class="message-content"><%= @summary %></div>
-</div>
-
- <div class="card-mobile mb-2">
-    <div class="message-author"><strong>Dernier message non répondu :</strong> <%= time_ago_in_words(@message.created_at) %> ago</div>
+  <div class="msg-bubble-pink mb-3">
+  <div class="reply-block-title">Dernier message non-répondu</div>
+  <div class="card-mobile msg-inner-bubble mb-0">
     <div class="message-content"><%= @message.content %></div>
+    <div class="message-date text-end">Il y a <%= time_ago_in_words(@message.created_at) %></div>
   </div>
+</div>
 
-  <div class="card-mobile mb-2">
-    <div class="message-author"><strong>Suggestion de réponse</strong></div>
-    <div class="message-content"> <%= @message.ai_draft %></div>
-    <%= link_to "Editer", edit_message_path(@message), class: "btn btn-pink mt-2" %>
+<div class="msg-bubble-pink mb-3">
+  <div class="reply-block-title">Suggestion de réponse :</div>
+  <div class="card-mobile msg-inner-bubble mb-0">
+    <div class="message-content"><%= @message.ai_draft %></div>
   </div>
+  <div class="reply-btn-row">
+    <%= form_with url: send_message_message_path(@message), method: :post, local: true do |form| %>
+    <%= form.hidden_field :user_answer, value: @message.ai_draft %>
+    <%= form.submit "Envoyer", class: "btn btn-pink reply-btn" %>
+     <% end %>
+    <%= link_to "Editer", edit_message_path(@message), class: "btn btn-pink reply-btn" %>
+  </div>
+</div>
+
+<% if @history_messages.present? %>
+  <div class="msg-bubble-pink mb-2">
+    <div class="reply-block-title">
+      <%= @message.contact.name %> fait partie de votre entourage proche !<br>
+      Voici un résumé de vos derniers échanges :
+    </div>
+    <% @history_messages.each do |m| %>
+      <div class="card-mobile msg-inner-bubble mb-1">
+        <div class="message-content"><%= m.content %></div>
+        <div class="message-date text-end">Il y a <%= time_ago_in_words(m.created_at) %></div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       patch :dismiss_suggestion
       get :reply
       get :rekonect
+      post :send_message
     end
   end
   get 'contacts/circles', to: 'contacts#circles', as: :contact_circles


### PR DESCRIPTION
refonte complète de la page reply pour matcher le figma mobile
ajout de l'affichage de l'historique des 3 derniers messages envoyés avec le contact courant
scss custom 
ajoute de la route post send_message et policy Pundit et methode dans le msg controller
responsive pour les TOUS petits écrans