### PR TITLE
Fix reply and seeds

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,7 +51,6 @@ class ApplicationController < ActionController::Base
   # Derniers messages reçus non ignorés par l'utilisateur courant.
   received_messages = last_messages_by_contact.values.select do |msg|
     msg.receiver_id == current_user.id &&
-    msg.status == "sent" &&
     (msg.dismissed == false || msg.dismissed.nil?)
   end
 
@@ -73,17 +72,13 @@ end
   def quick_messages
     # On récupère les derniers messages envoyés par contact
     sent_messages = last_messages_by_contact.values.select do |msg|
-      msg.sender_id == current_user.id && msg.status == "sent"
+      msg.sender_id == current_user.id
     end
-
-    # on enlève les doublons de content car la seed génère plusieurs messages avec le même contenu et le même contact
-    # à corriger dans la seed pour éviter de devoir faire ça en production
-    unique_messages = sent_messages.uniq { |msg| msg.content }
 
     # Trie les messages par ancienneté croissante puis par proximité décroissante.
     # On prend les 3 premiers messages après le tri.
     # La proximité est inversée pour que les contacts les plus proches soient prioritaires.
-    prioritized = unique_messages
+    prioritized = sent_messages
       .sort_by { |msg| [msg.created_at, -(msg.contact.relationship.proximity || 1)] }
       .first(3)
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -2,32 +2,33 @@ class ConversationsController < ApplicationController
   skip_after_action :verify_authorized, only: [:show]
 
   def show
-    if params[:contact_name].present?
-      contact_name = params[:contact_name].tr('-', ' ')
-      contact = Contact.find_by('LOWER(name) = ?', contact_name.downcase)
-      if contact.nil?
-        redirect_to root_path, alert: "Contact introuvable." and return
-      end
-      # Cherche la conversation existante entre current_user et ce contact
-      @conversation = Conversation.find_by(
-        contact_id: contact&.id,
-        user1_id: current_user.id,
-        user2_id: contact.contact_user_id
-      ) || Conversation.find_by(
-        contact_id: contact&.id,
-        user1_id: contact.contact_user_id,
-        user2_id: current_user.id
-      )
-      # Si elle n'existe pas, crée-la
-      if @conversation.nil? && contact.present?
-        @conversation = Conversation.create(contact_id: contact.id, user1_id: current_user.id, user2_id: contact.user_id)
-      end
-    elsif params[:id].present?
-      @conversation = Conversation.find_by(id: params[:id])
-    else
-      redirect_to root_path, alert: "Conversation introuvable." and return
-    end
+    # if params[:contact_name].present?
+    #   contact_name = params[:contact_name].tr('-', ' ')
+    #   contact = Contact.find_by('LOWER(name) = ?', contact_name.downcase)
+    #   if contact.nil?
+    #     redirect_to root_path, alert: "Contact introuvable." and return
+    #   end
+    #   # Cherche la conversation existante entre current_user et ce contact
+    #   @conversation = Conversation.find_by(
+    #     contact_id: contact&.id,
+    #     user1_id: current_user.id,
+    #     user2_id: contact.contact_user_id
+    #   ) || Conversation.find_by(
+    #     contact_id: contact&.id,
+    #     user1_id: contact.contact_user_id,
+    #     user2_id: current_user.id
+    #   )
+    #   # Si elle n'existe pas, crée-la
+    #   if @conversation.nil? && contact.present?
+    #     @conversation = Conversation.create(contact_id: contact.id, user1_id: current_user.id, user2_id: contact.user_id)
+    #   end
+    # elsif params[:id].present?
+    #   @conversation = Conversation.find_by(id: params[:id])
+    # else
+    #   redirect_to root_path, alert: "Conversation introuvable." and return
+    # end
 
+    @conversation = Conversation.find(params[:id])
     if @conversation.nil?
       redirect_to root_path, alert: "Conversation introuvable." and return
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,14 +5,13 @@ class MessagesController < ApplicationController
   def index
     @messages = policy_scope(Message)
     authorize @messages
-
-    # Sélectionne les messages en attente de réponse du user
-    # (uniquement ceux qui sont les derniers messages de chaque conversation)
-    subquery = @messages
-      .where.not(sender_id: current_user.id)
-      .select('DISTINCT ON (conversation_id) *')
-      .order('conversation_id, created_at DESC')
-    @awaiting_messages = Message.from(subquery, :messages)
+    @awaiting_messages = @messages.where(status: :sent)
+                          .where.not(sender_id: current_user.id)
+                          .select do |msg|
+                            Message.where(conversation_id: msg.conversation_id)
+                            .order(created_at: :desc)
+                            .first == msg
+                          end
     @contacts = current_user.contacts
     @sent_messages = current_user.sent_messages
     @received_messages = current_user.received_messages

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -15,7 +15,7 @@ class Message < ApplicationRecord
   validate :content_or_ai_draft_or_user_answer_present
 
   # Date d’envoi optionnelle, pas dans le futur, peut être blanc
-  validates :sent_at, allow_blank: true, comparison: { less_than_or_equal_to: Date.today }
+  # validates :sent_at, allow_blank: true, comparison: { less_than_or_equal_to: Date.today }
 
   validates :sender, presence: true
   validates :receiver, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   has_many :badges, through: :user_badges
   has_many :sent_messages, class_name: "Message", foreign_key: :sender_id
   has_many :received_messages, class_name: "Message", foreign_key: :receiver_id
+  has_many :conversations_as_asker, class_name: "Conversation", foreign_key: :user1_id
+  has_many :conversations_as_receiver, class_name: "Conversation", foreign_key: :user2_id
 
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -63,11 +63,7 @@
           </div>
           <div class="contact-name"><%= msg.contact.name %></div>
           <div class="contact-date">
-            <% if msg.sent_at.present? %>
-              <%= time_ago_in_words(msg.sent_at) %>
-            <% else %>
-              <span>Date inconnue</span>
-            <% end %>
+              <%= time_ago_in_words(msg.created_at) %>
           </div>
           <%= link_to "Rekonect", rekonect_message_path(msg), class: "btn btn-pink btn-sm" %>
         </div>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -15,34 +15,32 @@
 </div>
 
 <div class="msg-bubble-pink mb-3">
-  <div class="collapsible-header" style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;" data-target="section2">
-    <div class="reply-block-title" style="margin: 0;">Dernier message non-répondu</div>
-    <span class="toggle-arrow" style="font-size: 1.5em;">˅</span>
+  <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('last-message-block', 'icon-last')">
+    <span>Dernier message non-répondu</span>
+    <span id="icon-last">▼</span>
   </div>
-  <div id="section2" class="collapsible-content" style="transition: max-height 0.3s ease; overflow: hidden;">
-    <div class="card-mobile msg-inner-bubble mb-0" style="margin-top: 10px;">
+  <div id="last-message-block" class="slide-toggle open">
+    <div class="card-mobile msg-inner-bubble mb-0">
       <div class="message-content"><%= @message.content %></div>
       <div class="message-date text-end">Il y a <%= time_ago_in_words(@message.created_at) %></div>
     </div>
   </div>
 </div>
 
-<% if @history_messages.present? %>
+<% if @summary.present? %>
   <div class="msg-bubble-pink mb-2">
-    <div class="collapsible-header" style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;" data-target="section3">
-      <div class="reply-block-title" style="margin: 0;">
+    <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('history-messages-block', 'icon-history')">
+      <div>
         <%= @message.contact.name %> fait partie de votre entourage proche !<br>
         Voici un résumé de vos derniers échanges :
       </div>
-      <span class="toggle-arrow" style="font-size: 1.5em;">▾</span>
+      <span id="icon-history">▼</span>
     </div>
-    <div id="section3" class="collapsible-content" style="transition: max-height 0.3s ease; overflow: hidden;">
-      <% @history_messages.each do |m| %>
+
+    <div id="history-messages-block" class="slide-toggle open">
         <div class="card-mobile msg-inner-bubble mb-1">
-          <div class="message-content"><%= m.content %></div>
-          <div class="message-date text-end">Il y a <%= time_ago_in_words(m.created_at) %></div>
+          <div class="message-content"><%= @summary %></div>
         </div>
-      <% end %>
     </div>
   </div>
 <% end %>
@@ -52,16 +50,14 @@
   <div class="card-mobile msg-inner-bubble mb-0">
     <%= simple_form_for Message.new do |f| %>
       <%= f.input :conversation_id, as: :hidden, input_html: { value: @conversation.id } %>
-      <%= f.input :content, as: :text, input_html: { value: @message.ai_draft, rows: 5 } %>
+      <%= f.input :content, label: "Votre réponse", as: :text, input_html: { value: @message.ai_draft, rows: 5 } %>
       <%= f.submit "Envoyer", class: "btn btn-pink reply-btn edit-form-btn" %>
     <% end %>
 
 
     <%#= form_with(model: @message, local: true) do |form| %>
-      <div class="mb-3">
-        <%#= form.label :content, "Votre réponse" %>
-        <%#= form.text_area :content, value: @message.ai_draft.presence || @message.content, rows: 5, class: "input-mobile" %>
-      </div>
+      <%#= form.label :content, "Votre réponse" %>
+      <%#= form.text_area :content, value: @message.ai_draft.presence || @message.content, rows: 5, class: "input-mobile" %>
       <%#= form.submit "Envoyer", class: "btn btn-pink reply-btn edit-form-btn" %>
     <%# end %>
   </div>
@@ -70,31 +66,20 @@
 <%= render 'shared/navbar_bottom' %>
 
 <script>
-  document.addEventListener("DOMContentLoaded", function() {
-    document.querySelectorAll('.collapsible-header').forEach(function(header) {
-      header.addEventListener('click', function() {
-        const targetId = header.dataset.target;
-        const content = document.getElementById(targetId);
-        const arrow = header.querySelector('.toggle-arrow');
+ function toggleBlock(blockId, iconId) {
+  const block = document.getElementById(blockId);
+  const icon = document.getElementById(iconId);
 
-        if (content.style.maxHeight && content.style.maxHeight !== "0px") {
-          // Collapse
-          content.style.maxHeight = "0";
-          arrow.textContent = "▾";  // Flèche vers le bas
-        } else {
-          // Expand
-          content.style.maxHeight = content.scrollHeight + "px";
-          arrow.textContent = "▴";  // Flèche vers le haut
-        }
-      });
-    });
+  if (!block || !icon) return;
 
-    // Initial collapse the sections if you want (optional)
-    ['section1', 'section2'].forEach(function(id) {
-      const el = document.getElementById(id);
-      if(el) {
-        el.style.maxHeight = el.scrollHeight + "px"; // start expanded
-      }
-    });
-  });
+  const isOpen = block.classList.contains("open");
+
+  if (isOpen) {
+    block.classList.remove("open");
+    icon.innerHTML = "<i class='fas fa-chevron-down'></i>";
+  } else {
+    block.classList.add("open");
+    icon.innerHTML = "<i class='fas fa-chevron-up'></i>";
+  }
+}
 </script>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -50,13 +50,20 @@
 <div class="msg-bubble-pink mb-3">
   <div class="reply-block-title">Modification de la réponse à envoyer :</div>
   <div class="card-mobile msg-inner-bubble mb-0">
-    <%= form_with(model: @message, local: true) do |form| %>
-      <div class="mb-3">
-        <%= form.label :content, "Votre réponse" %>
-        <%= form.text_area :content, value: @message.content.presence || @message.ai_draft, rows: 5, class: "input-mobile" %>
-      </div>
-      <%= form.submit "Envoyer", class: "btn btn-pink reply-btn edit-form-btn" %>
+    <%= simple_form_for Message.new do |f| %>
+      <%= f.input :conversation_id, as: :hidden, input_html: { value: @conversation.id } %>
+      <%= f.input :content, as: :text, input_html: { value: @message.ai_draft, rows: 5 } %>
+      <%= f.submit "Envoyer", class: "btn btn-pink reply-btn edit-form-btn" %>
     <% end %>
+
+
+    <%#= form_with(model: @message, local: true) do |form| %>
+      <div class="mb-3">
+        <%#= form.label :content, "Votre réponse" %>
+        <%#= form.text_area :content, value: @message.ai_draft.presence || @message.content, rows: 5, class: "input-mobile" %>
+      </div>
+      <%#= form.submit "Envoyer", class: "btn btn-pink reply-btn edit-form-btn" %>
+    <%# end %>
   </div>
 </div>
 

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,6 +1,6 @@
 <h2 class="dashboard-header">Mes messages</h2>
 
-<% awaiting_messages = @messages.select { |m| m.status == "draft_by_ai" && (m.dismissed == false || m.dismissed.nil?) } %>
+<% awaiting_messages = @awaiting_messages  %>
 <% if awaiting_messages.any? %>
   <div class="messages-list">
     <% awaiting_messages.each do |message| %>
@@ -16,7 +16,7 @@
         </div>
         <div class="message-actions">
           <%= link_to "Rekonect", rekonect_message_path(message), class: "btn btn-rekonect" %>
-          <%= link_to "Conversation", conversation_by_name_path(contact_name: message.contact.name.parameterize), class: "btn btn-conversation" %>
+          <%= link_to "Conversation", conversation_path(message.conversation), class: "btn btn-conversation" %>
         </div>
       </div>
     <% end %>
@@ -26,18 +26,18 @@
 <% end %>
 <%= render "shared/navbar_bottom" %>
 
-<h2>Mes contacts</h2>
+<h2>Mes conversations</h2>
 <div class="contacts-list">
-  <% @contacts.each do |contact| %>
-    <%= link_to conversation_by_name_path(contact_name: contact.name.parameterize), class: "contact-card" do %>
+  <% @conversations.each do |conversation| %>
+    <%= link_to conversation_path(conversation), class: "contact-card" do %>
       <div class="contact-avatar">
-        <% if contact.photo.attached? %>
-          <%= image_tag contact.photo, class: "avatar-img" %>
+        <% if conversation.contact.photo.attached? %>
+          <%= image_tag conversation.contact.photo, class: "avatar-img" %>
         <% else %>
           <%= image_tag "default-avatar.png", class: "avatar-img" %>
         <% end %>
       </div>
-      <div class="contact-name"><%= contact.name %></div>
+      <div class="contact-name"><%= conversation.contact.name %></div>
     <% end %>
   <% end %>
 </div>

--- a/app/views/messages/reply.html.erb
+++ b/app/views/messages/reply.html.erb
@@ -27,7 +27,7 @@
 </div>
 
 <!-- Historique -->
-<% if @history_messages.present? %>
+<% if @summary.present? %>
   <div class="msg-bubble-pink mb-2">
     <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('history-messages-block', 'icon-history')">
       <div>
@@ -38,12 +38,9 @@
     </div>
 
     <div id="history-messages-block" class="slide-toggle open">
-      <% @history_messages.each do |m| %>
         <div class="card-mobile msg-inner-bubble mb-1">
-          <div class="message-content"><%= m.content %></div>
-          <div class="message-date text-end">Il y a <%= time_ago_in_words(m.created_at) %></div>
+          <div class="message-content"><%= @summary %></div>
         </div>
-      <% end %>
     </div>
   </div>
 <% end %>
@@ -61,10 +58,6 @@
       <%= f.submit "Envoyer", class: "btn btn-pink reply-btn" %>
     <% end %>
 
-    <%#= form_with url: send_message_message_path(@message), method: :post, local: true do |form| %>
-      <%#= form.hidden_field :user_answer, value: @message.ai_draft %>
-      <%#= form.submit "Envoyer", class: "btn btn-pink reply-btn" %>
-    <%# end %>
     <%= link_to "Editer", edit_message_path(@message), class: "btn btn-pink reply-btn" %>
   </div>
 </div>

--- a/app/views/messages/reply.html.erb
+++ b/app/views/messages/reply.html.erb
@@ -55,10 +55,16 @@
     <div class="message-content"><%= @message.ai_draft %></div>
   </div>
   <div class="reply-btn-row">
-    <%= form_with url: send_message_message_path(@message), method: :post, local: true do |form| %>
-      <%= form.hidden_field :user_answer, value: @message.ai_draft %>
-      <%= form.submit "Envoyer", class: "btn btn-pink reply-btn" %>
+    <%= simple_form_for Message.new do |f| %>
+      <%= f.input :conversation_id, as: :hidden, input_html: { value: @conversation.id } %>
+      <%= f.input :content, as: :hidden, input_html: { value: @message.ai_draft } %>
+      <%= f.submit "Envoyer", class: "btn btn-pink reply-btn" %>
     <% end %>
+
+    <%#= form_with url: send_message_message_path(@message), method: :post, local: true do |form| %>
+      <%#= form.hidden_field :user_answer, value: @message.ai_draft %>
+      <%#= form.submit "Envoyer", class: "btn btn-pink reply-btn" %>
+    <%# end %>
     <%= link_to "Editer", edit_message_path(@message), class: "btn btn-pink reply-btn" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,6 @@ Rails.application.routes.draw do
   end
   get 'contacts/circles', to: 'contacts#circles', as: :contact_circles
   resources :contacts
-  get 'conversations/:contact_name', to: 'conversations#show', as: :conversation_by_name
   resources :conversations, only: [:show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
Changements principaux : simplification des seeds, suppression de méthodes inutiles, l’ajout de méthodes réutilisables, et la mise à jour des vues et routes pour plus de cohérence.

Changements dans la gestion des messages :

- Suppression de la condition status == "sent" dans les méthodes main_message et quick_messages pour simplifier le filtrage des messages.
- Ajout d’une méthode history_messages pour récupérer l’historique des messages, évitant la répétition de code dans les actions reply et edit.
- Amélioration de la méthode message_summary pour un résumé plus clair et facile à lire.

Changements dans la gestion des conversations :

- Simplification de l’action show en supprimant la recherche ou création de conversation par nom, en utilisant seulement l’ID de la conversation.
- Suppression de la route conversation_by_name et utilisation uniquement de la route standard conversation_path.

Changements dans les vues :

- Mise à jour des vues edit.html.erb et reply.html.erb pour afficher les résumés au lieu des messages individuels, ce qui améliore la lisibilité.
- Modification du tableau de bord pour afficher à nouveau la date de réception des messages.
- Mise à jour de la liste des messages pour utiliser les conversations au lieu des contacts.

Nettoyage et simplification du code :

- Suppression de la validation inutile pour sent_at dans le modèle Message.
- Ajout d’associations dans le modèle User pour mieux gérer les conversations et faciliter les requêtes.




https://github.com/user-attachments/assets/a5ccac47-bdf6-4db1-b7e5-6daeae32f308


https://github.com/user-attachments/assets/fbea142b-9fae-4aa1-907a-9a22d2f28190