### PR TITLE
vue rekonect copiée sur la vue reply + factorisation dans les controleurs

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,5 +1,6 @@
 class ContactsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_contact, only: [:show, :edit, :update]
   skip_after_action :verify_authorized, only: [:circles]
 
   def index
@@ -22,18 +23,12 @@ class ContactsController < ApplicationController
   end
 
   def show
-    @contact = Contact.find(params[:id])
-    authorize @contact
   end
 
   def edit
-    @contact = Contact.find(params[:id])
-    authorize @contact
   end
 
   def update
-    @contact = Contact.find(params[:id])
-    authorize @contact
     if @contact.update(contact_params)
       redirect_to contact_path(@contact), notice: "Contact mis à jour avec succès."
     else
@@ -46,6 +41,11 @@ class ContactsController < ApplicationController
   end
 
   private
+
+  def set_contact
+    @contact = Contact.find(params[:id])
+    authorize @contact
+  end
 
   def contact_params
     params.require(:contact).permit(:name, :notes, :relationship_id, :photo)

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -48,7 +48,7 @@
 <% quick_msgs = @quick_messages %>
 <% if quick_msgs.any? %>
   <div class="quick-contacts-card">
-    <div class="quick-contacts-title">Et sinon ?</div>
+    <div class="quick-contacts-title">Et si on relançait la conversation avec ?</div>
     <div class="quick-contacts-list">
       <% quick_msgs.each do |msg| %>
         <div class="quick-contact">

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="reply-header">
   <div class="collapsible-header" style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;" data-target="section1">
-    <h1 class="reply-title" style="margin: 0;">Prends donc un peu de temps pour</h1>
+    <h1 class="reply-title" style="margin: 0;"><%= @message.sender == current_user ? "Peut-être est-il temps de relancer la conversation avec :" : "Prends donc un peu de temps pour :" %></h1>
   </div>
   <div id="section1" class="collapsible-content" style="transition: max-height 0.3s ease; overflow: hidden;">
     <div class="reply-avatar-block" style="margin-top: 10px;">
@@ -16,7 +16,7 @@
 
 <div class="msg-bubble-pink mb-3">
   <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('last-message-block', 'icon-last')">
-    <span>Dernier message non-répondu</span>
+    <span><%= @message.sender == current_user ? "Dernier message de ta part" : "Dernier message non-répondu" %></span>
     <span id="icon-last">▼</span>
   </div>
   <div id="last-message-block" class="slide-toggle open">

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -15,7 +15,7 @@
           <%= message.ai_draft.presence || "Aucune suggestion disponible." %>
         </div>
         <div class="message-actions">
-          <%= link_to "Rekonect", rekonect_message_path(message), class: "btn btn-rekonect" %>
+          <%= link_to "Rekonect", reply_message_path(message), class: "btn btn-rekonect" %>
           <%= link_to "Conversation", conversation_path(message.conversation), class: "btn btn-conversation" %>
         </div>
       </div>

--- a/app/views/messages/rekonect.html.erb
+++ b/app/views/messages/rekonect.html.erb
@@ -16,7 +16,7 @@
 <div class="msg-bubble-pink mb-3">
   <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('last-message-block', 'icon-last')">
     <span>Dernier message de ta part</span>
-    <span id="icon-last">▼</span>
+    <span id="icon-last"><i class='fas fa-chevron-up'></i></span>
   </div>
   <div id="last-message-block" class="slide-toggle open">
     <div class="card-mobile msg-inner-bubble mb-0">
@@ -35,7 +35,7 @@
         <%= @message.contact.name %> fait partie de votre entourage proche !<br>
         Voici un résumé de vos derniers échanges :
       </div>
-      <span id="icon-history">▼</span>
+      <span id="icon-history"><i class='fas fa-chevron-up'></i></span>
     </div>
 
     <div id="history-messages-block" class="slide-toggle open">
@@ -60,7 +60,7 @@
       <%= f.submit "Envoyer", class: "btn btn-pink reply-btn" %>
     <% end %>
 
-    <%= link_to "Editer", edit_message_path(@message), class: "btn btn-pink reply-btn" %>
+    <%= link_to "Modifier", edit_message_path(@message), class: "btn btn-pink reply-btn" %>
   </div>
 </div>
 

--- a/app/views/messages/rekonect.html.erb
+++ b/app/views/messages/rekonect.html.erb
@@ -1,19 +1,84 @@
-<div class="dashboard-header">
-  <h2>Peut-être est-il temps de relancer la conversation avec <%= @message.contact.name %> ?</h2>
-  <p class="dashboard-welcome">Voici un résumé de vos derniers échanges</p>
+<div class="reply-header">
+  <div>
+    <h1 class="reply-title">Peut-être est-il temps de relancer la conversation avec :</h1>
+  </div>
+  <div class="reply-avatar-block">
+    <% if @message.contact.photo.attached? %>
+      <%= image_tag @message.contact.photo.variant(resize_to_fill: [38, 38]), class: "avatar-mobile ms-2" %>
+    <% else %>
+      <%= image_tag "default-avatar.png", class: "avatar-mobile" %>
+    <% end %>
+    <span class="reply-contact-name"><%= @message.contact.name %></span>
+  </div>
 </div>
 
-<div class="card-mobile mb-2">
-    <div class="message-content"><%= @summary %></div>
+<!-- Dernier message envoyé par l'utilisateur et resté sans réponse -->
+<div class="msg-bubble-pink mb-3">
+  <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('last-message-block', 'icon-last')">
+    <span>Dernier message de ta part</span>
+    <span id="icon-last">▼</span>
+  </div>
+  <div id="last-message-block" class="slide-toggle open">
+    <div class="card-mobile msg-inner-bubble mb-0">
+      <div class="message-content"><%= @message.content %></div>
+      <div class="message-date text-end">Il y a <%= time_ago_in_words(@message.created_at) %></div>
+    </div>
+  </div>
 </div>
 
-  <div class="card-mobile mb-2">
-    <div class="message-author"><strong>Dernier message de ta part :</strong> <%= time_ago_in_words(@message.created_at) %> ago</div>
-    <div class="message-content"><%= @message.content %></div>
-  </div>
 
-  <div class="card-mobile mb-2">
-    <div class="message-author"><strong>Suggestion de relance</strong></div>
-    <div class="message-content"> <%= @new_message.ai_draft %></div>
-    <%= link_to "Éditer", edit_message_path(@message), class: "btn btn-edit" if @message&.id.present? %>
+<!-- Historique -->
+<% if @summary.present? %>
+  <div class="msg-bubble-pink mb-2">
+    <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('history-messages-block', 'icon-history')">
+      <div>
+        <%= @message.contact.name %> fait partie de votre entourage proche !<br>
+        Voici un résumé de vos derniers échanges :
+      </div>
+      <span id="icon-history">▼</span>
+    </div>
+
+    <div id="history-messages-block" class="slide-toggle open">
+        <div class="card-mobile msg-inner-bubble mb-1">
+          <div class="message-content"><%= @summary %></div>
+        </div>
+    </div>
   </div>
+<% end %>
+
+
+<!-- Suggestion de réponse (toujours visible) -->
+<div class="msg-bubble-pink mb-3">
+  <div class="reply-block-title">Suggestion de relance :</div>
+  <div class="card-mobile msg-inner-bubble mb-0">
+    <div class="message-content"><%= @message.ai_draft %></div>
+  </div>
+  <div class="reply-btn-row">
+    <%= simple_form_for Message.new do |f| %>
+      <%= f.input :conversation_id, as: :hidden, input_html: { value: @conversation.id } %>
+      <%= f.input :content, as: :hidden, input_html: { value: @message.ai_draft } %>
+      <%= f.submit "Envoyer", class: "btn btn-pink reply-btn" %>
+    <% end %>
+
+    <%= link_to "Editer", edit_message_path(@message), class: "btn btn-pink reply-btn" %>
+  </div>
+</div>
+
+<script>
+function toggleBlock(blockId, iconId) {
+  const block = document.getElementById(blockId);
+  const icon = document.getElementById(iconId);
+
+  if (!block || !icon) return;
+
+  const isOpen = block.classList.contains("open");
+
+  if (isOpen) {
+    block.classList.remove("open");
+    icon.innerHTML = "<i class='fas fa-chevron-down'></i>";
+  } else {
+    block.classList.add("open");
+    icon.innerHTML = "<i class='fas fa-chevron-up'></i>";
+  }
+}
+</script>

--- a/app/views/messages/reply.html.erb
+++ b/app/views/messages/reply.html.erb
@@ -16,7 +16,7 @@
 <div class="msg-bubble-pink mb-3">
   <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('last-message-block', 'icon-last')">
     <span>Dernier message non-répondu</span>
-    <span id="icon-last">▼</span>
+    <span id="icon-last"><i class='fas fa-chevron-up'></i></span>
   </div>
   <div id="last-message-block" class="slide-toggle open">
     <div class="card-mobile msg-inner-bubble mb-0">
@@ -34,7 +34,7 @@
         <%= @message.contact.name %> fait partie de votre entourage proche !<br>
         Voici un résumé de vos derniers échanges :
       </div>
-      <span id="icon-history">▼</span>
+      <span id="icon-history"><i class='fas fa-chevron-up'></i></span>
     </div>
 
     <div id="history-messages-block" class="slide-toggle open">
@@ -58,7 +58,7 @@
       <%= f.submit "Envoyer", class: "btn btn-pink reply-btn" %>
     <% end %>
 
-    <%= link_to "Editer", edit_message_path(@message), class: "btn btn-pink reply-btn" %>
+    <%= link_to "Modifier", edit_message_path(@message), class: "btn btn-pink reply-btn" %>
   </div>
 </div>
 


### PR DESCRIPTION
Changements dans les contrôleurs

ContactsController :

- Ajout d'une méthode privée set_contact pour éviter de répéter Contact.find et authorize dans plusieurs actions comme show, edit et update.

MessagesController :

- Ajout des méthodes privées set_message et reply_rekonect pour centraliser la recherche, l'autorisation des messages, et préparer l'historique et les résumés pour reply et rekonect.
- Simplification des actions rekonect et reply en utilisant ces méthodes.
- Amélioration de la requête awaiting_messages en enlevant des filtres inutiles.

Améliorations des vues

dashboard/index.html.erb :

- Changement du titre de la section des contacts rapides pour le rendre plus clair et attractif.

messages/edit.html.erb :

- Affichage dynamique du titre et des labels selon que l'utilisateur est l'expéditeur du message ou pas.

messages/index.html.erb :

- Le bouton "Rekonect" redirige maintenant vers l'action reply pour un parcours plus cohérent.

messages/rekonect.html.erb :

- Nouvelle organisation avec sections pour le dernier message, l'historique, et les suggestions IA, avec des blocs repliables via un script JavaScript.

Fonctionnalités ajoutées

- Le prompt IA dans rekonect_suggestion utilise désormais le dernier message de l'utilisateur pour offrir des suggestions plus adaptées.