### PR TITLE
fix(devise): unifie design, liens et CTA entre login/register avec refacto SCSS et accessibilité améliorée avec plein d'émojis

### DIFF
--- a/app/assets/stylesheets/components/_devise_card.scss
+++ b/app/assets/stylesheets/components/_devise_card.scss
@@ -90,3 +90,86 @@
   flex-direction: column;
   align-items: center;
 }
+
+.devise-links {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.devise-links a {
+  color: #B27AE8;
+  font-weight: 700;
+  font-size: 1.09rem;
+  text-decoration: none;
+  letter-spacing: 0.01em;
+  text-shadow: 0 2px 8px #fff, 0 0 2px #fff;
+  transition: color 0.18s, text-shadow 0.18s;
+
+  &:hover {
+    color: #e573a4;
+    text-shadow: 0 2px 12px #e573a4AA, 0 0 8px #fff;
+    text-decoration: underline;
+  }
+}
+
+.cta-signup {
+  display: inline-block;
+  margin: 28px auto 14px auto;
+  padding: 0.72em 2.5em;
+  font-size: 1.13rem;
+  font-weight: 800;
+  border-radius: 23px;
+  background: linear-gradient(97deg, #ffb8d0 0%, #b5a5e8 45%, #e573a4 100%);
+  color: #fff !important;
+  box-shadow: 0 4px 30px 0px #e573a47e, 0 1.5px 7px #b5a5e8a0;
+  letter-spacing: 0.04em;
+  border: 2.5px solid #fff6;
+  text-align: center;
+  text-decoration: none;
+  position: relative;
+  z-index: 2;
+  filter: drop-shadow(0 6px 16px #ffb8d055);
+  transition:
+    background 0.15s,
+    box-shadow 0.13s,
+    border 0.17s,
+    transform 0.13s;
+
+  &:hover,
+  &:focus {
+    background: linear-gradient(93deg, #e573a4 0%, #b5a5e8 60%, #ffb8d0 100%);
+    box-shadow: 0 7px 40px 3px #b5a5e8bb, 0 2px 9px #fff3;
+    border-color: #e573a4a6;
+    color: #fff !important;
+    transform: translateY(-2px) scale(1.045) rotate(-1deg);
+    outline: none;
+    filter: brightness(1.05) drop-shadow(0 0 12px #e573a499);
+  }
+
+  &:active {
+    transform: scale(0.96);
+    filter: brightness(0.97);
+  }
+
+}
+
+.devise-link-muted {
+  padding: 5px 16px;
+  border-radius: 20px;
+  border: 1.5px solid #e573a455;
+  background: $card-shadow;
+  color: black !important;
+  text-decoration: none !important;
+  box-shadow: 0 2px 14px #fff6;
+  font-weight: 600;
+
+  &:hover,
+  &:focus {
+    color: #e573a4 !important;
+    text-decoration: underline !important;
+    box-shadow: 0 4px 20px #e573a444;
+    background: #fff8;
+    outline: none;
+  }
+}

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="forgot-header">Forgot your password?</h2>
+<h2 class="forgot-header">Mot de passe oublié ?</h2>
 
 <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.error_notification %>
@@ -10,9 +10,7 @@
                 input_html: { autocomplete: "email" } %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Send me reset password instructions" %>
-  </div>
+    <%= f.button :submit, "Réinitialiser mon mot de passe" %>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,31 +1,68 @@
-<h2 class="signup-header">Sign up</h2>
+<div class="container-fluid py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6 col-12">
+      <div class="devise-header">
+        <%= image_tag "logo.png", alt: "Logo Rekonect", class: "devise-logo" %>
+        <div class="devise-title-block">
+          <h1 class="devise-title">Rekonect</h1>
+          <div class="app-slogan">
+            <i class="fas fa-comment-dots slogan-bubble"></i>
+            <span>Restes proches, simplement</span>
+          </div>
+        </div>
+        <p class="devise-desc">
+          Inscris-toi pour retrouver et garder le lien avec tes proches.<br>
+          Une inscription, et c’est parti pour des rappels sur-mesure !
+        </p>
+      </div>
+
+      <div class="devise-card card shadow-lg p-4">
+        <h2 class="text-center mb-3">Créer un compte Rekonect</h2>
+        <p class="text-center mb-4 text-muted" style="font-size: 1.08rem;">
+          On est ravi de t’accueillir dans la famille 🎉<br>
+        </p>
 
 <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= f.error_notification %>
 
   <div class="form-inputs">
+     <div class="input-with-icon">
+        <i class="fas fa-envelope"></i>
     <%= f.input :email,
                 required: true,
                 autofocus: true,
+                placeholder: "Ton email 📧",
                 input_html: { autocomplete: "email" }%>
-    <%= f.input :first_name, required: true, input_html: { autocomplete: "given-name" } %>
-    <%= f.input :last_name, required: true, input_html: { autocomplete: "family-name" } %>
-    <%= f.input :username, required: true, input_html: { autocomplete: "username" } %>
-    <%= f.input :address, required: true, input_html: { autocomplete: "street-address" } %>
-    <%= f.input :phone_number, required: true, input_html: { autocomplete: "tel" } %>
-    <%= f.input :birth_date, as: :string, input_html: { type: "date", autocomplete: "bday" } %>
+        <i class="fas fa-user"></i>
+    <%= f.input :first_name, required: true,  placeholder: "Prénom 👤", input_html: { autocomplete: "given-name" } %>
+        <i class="fas fa-user"></i>
+    <%= f.input :last_name, required: true, placeholder: "Nom de famille 👨‍👩‍👧‍👦", input_html: { autocomplete: "family-name" } %>
+         <i class="fas fa-user-circle"></i>
+    <%= f.input :username, required: true,  placeholder: "Pseudo unique 🚀", input_html: { autocomplete: "username" } %>
+        <i class="fas fa-map-marker-alt"></i>
+    <%= f.input :address, required: true, placeholder: "Adresse 🏡", input_html: { autocomplete: "street-address" } %>
+        <i class="fas fa-phone"></i>
+    <%= f.input :phone_number, required: true, placeholder: "Téléphone 📱",  input_html: { autocomplete: "tel" } %>
+        <i class="fas fa-birthday-cake"></i>
+    <%= f.input :birth_date, as: :string, placeholder: "Date de naissance 🎂", input_html: { type: "date", autocomplete: "bday" } %>
+        <i class="fas fa-lock"></i>
     <%= f.input :password,
                 required: true,
+                placeholder: "Mot de passe 🔑",
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
                 input_html: { autocomplete: "new-password" } %>
+                <i class="fas fa-lock"></i>
     <%= f.input :password_confirmation,
                 required: true,
+                placeholder: "Confirmation 🔑",
                 input_html: { autocomplete: "new-password" } %>
-  </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
+                <%= f.button :submit, "📝 S’inscrire", class: "devise-link mt-4" %>
+     </div>
+     </div>
+    <% end %>
+    </div>
+   </div>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>
+ <%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -25,19 +25,24 @@
 
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-inputs">
+    <div class="input-with-icon">
+      <i class="fas fa-envelope"></i>
     <%= f.input :email,
                 required: false,
                 autofocus: true,
                 input_html: { autocomplete: "email" } %>
+      <i class="fas fa-lock"></i>
     <%= f.input :password,
                 required: false,
                 input_html: { autocomplete: "current-password" } %>
     <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
-  </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
+    <%= f.button :submit, "🔓 Se connecter", class: "devise-link" %>
+          </div>
+        </div>
+        <% end %>
+        </div>
+      </div>
+    </div>
   </div>
-<% end %>
-
 <%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,13 +1,13 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "🔓 Se connecter", new_session_path(resource_name), class: "devise-link-muted" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "📝 S'inscrire", new_registration_path(resource_name), class: "cta-signup" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "🔒 Mot de passe oublié ?", new_password_path(resource_name), class: "devise-link-muted" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>


### PR DESCRIPTION
design cohérent entre login & registration avec devise-link (bouton) et devise-link-muted (lien discret)
uniformise les classes et le wording des liens (“se connecter”, “s’inscrire”, “mot de passe oublié ?”) dans le partial _links.html.erb
ajoute les icônes/emojis pour chaque champ, labels et boutons
enlevé le double bouton a cause de form action
revue complète des placeholders, ergonomie et accessibilité
nettoyage du SCSS : suppression des anciens styles welcome-image du dashboard
ajout d'un gros CTA s'inscrire avec linear gradient et effet animé si la personne n'a pas de compte
ajout de nouvelles classes devise dans _devise_card.scss

**Attention :** Bien réutiliser les mêmes class component par component s'il vous plaît et ne pas mettre de class global type h1 h2 body ( à moins qu e ce soit pour le background c'est pas grave) sinon ça override tout, écrire ses propres classes et les mettre dans les bons components scss sinon si on essaye de réutiliser ses balises dans une view le style global va écraser ce qu'on voudra faire même si on crée une classe et qu '
on la module dans les composants scss, tres important !

<img width="430" height="932" alt="brave_HhbjE92ZkG" src="https://github.com/user-attachments/assets/eb4bbc4b-8241-4828-a72e-873d60696b6c" />
<img width="429" height="931" alt="brave_GzEWFuiUsn" src="https://github.com/user-attachments/assets/4ffe2922-a199-4cd7-949e-29344374641f" />
<img width="430" height="932" alt="brave_VrZY19XbAU" src="https://github.com/user-attachments/assets/5e9e7fd6-fc62-48d2-bc34-909f7302b529" />
<img width="433" height="934" alt="brave_6czRmHLcDJ" src="https://github.com/user-attachments/assets/e921bfae-8705-44d2-bf1d-55c0f2279013" />
<img width="431" height="935" alt="brave_UGVT0HJfno" src="https://github.com/user-attachments/assets/c32d4b0b-a1cb-4c9c-b93c-228ad0cf53c8" />
