### PR TITLE
Improve ai

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -169,7 +169,7 @@ class MessagesController < ApplicationController
         model: "gpt-4o-mini",
         messages: [
           { role: "system", content: "You are a helpful assistant that generates messages." },
-          { role: "user", content: "You are #{current_user.first_name}. Last time you wrote to #{message.contact.name} was #{message.created_at} and today is #{Time.current}. This is the background of the conversation between you two: #{summary}. This is the last message you sent : #{message.content}. Generate in French a warmful message of 50 words max to recreate a conversation with this contact without repeating the summary as it is meant only for you and not for being in the reply. Keep in mind that some time has passed since your last message so the context may have changed." }
+          { role: "user", content: "You are #{current_user.first_name}. Last time you wrote to #{message.contact.name} was #{message.created_at} and today is #{Time.current}. This is the background of the conversation between you two: #{summary}. This is the last message you sent : #{message.content}. It was the last message between you two. Generate in French a warmful message of 50 words max to recreate a conversation with this contact without repeating the summary as it is meant only for you and not for being in the reply. Keep in mind that some time has passed since your last message so the context may have changed." }
         ]
       }
     )

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -123,13 +123,13 @@ class MessagesController < ApplicationController
       parameters: {
         model: "gpt-4o-mini",
         messages: [
-          { role: "system", content: "You are a helpful assistant that summarizes conversations." },
+          { role: "system", content: "You are a helpful assistant that summarizes conversations between two people." },
           {
             role: "user",
             content:
               "Make a very short recap (80 words max) in French of each interaction between " \
               "#{messages.first&.contact&.name} and the user #{current_user.first_name}. " \
-              "The user is #{current_user.first_name}. Speak directly to him, don't use his name: " \
+              "The user is #{current_user.first_name} and the recap will only be read by him. Speak directly to him, don't use his name at all: " \
               "#{messages.map { |m| "date d'envoi: #{m.created_at}, message de #{m.sender_id == current_user.id ? current_user.first_name : m.contact.name}: #{m.content}" }.join(", ")}"
           }
         ]
@@ -151,7 +151,7 @@ class MessagesController < ApplicationController
         model: "gpt-4o-mini",
         messages: [
           { role: "system", content: "You are a helpful assistant that generates message replies." },
-          { role: "user", content: "This is the background of the conversation: #{summary}. This is the last message you received : #{message.content}. Generate in French a warmful reply of 50 words max to this last message without repeating the summary as it is meant only for you and not for being in the reply." }
+          { role: "user", content: "You are #{current_user.first_name}. This is the background of the conversation with #{message.contact.name}: #{summary}. This is the last message you received : #{message.content}. It was sent #{message.created_at} and today is #{Time.current}. Generate in French a warmful reply of 50 words max to this last message without repeating the summary as it is meant only for you and not for being in the reply. Take into account that some time has passed and the context may have changed." }
         ]
       }
     )
@@ -169,7 +169,7 @@ class MessagesController < ApplicationController
         model: "gpt-4o-mini",
         messages: [
           { role: "system", content: "You are a helpful assistant that generates messages." },
-          { role: "user", content: "It has been a long time since you last wrote to #{message.contact.name}. This is the background of the conversation: #{summary}. This is the last message you sent : #{message.content}. Generate in French a warmful message of 50 words max to recreate a conversation with this contact without repeating the summary as it is meant only for you and not for being in the reply." }
+          { role: "user", content: "You are #{current_user.first_name}. Last time you wrote to #{message.contact.name} was #{message.created_at} and today is #{Time.current}. This is the background of the conversation between you two: #{summary}. This is the last message you sent : #{message.content}. Generate in French a warmful message of 50 words max to recreate a conversation with this contact without repeating the summary as it is meant only for you and not for being in the reply. Keep in mind that some time has passed since your last message so the context may have changed." }
         ]
       }
     )

--- a/app/views/messages/_ai_suggestion.html.erb
+++ b/app/views/messages/_ai_suggestion.html.erb
@@ -7,7 +7,7 @@
     <%= simple_form_for Message.new do |f| %>
       <%= f.input :conversation_id, as: :hidden, input_html: { value: conversation.id } %>
       <%= f.input :content, as: :hidden, input_html: { value: message.ai_draft } %>
-      <%= f.submit "Envoyer", class: "btn btn-pink reply-btn" %>
+      <%= f.submit "Envoyer", class: "btn btn-pink reply-btn", data: { turbo: false } %>
     <% end %>
 
     <%= link_to "Modifier", edit_message_path(message), data: { turbo_frame: :message_suggestion }, class: "btn btn-pink reply-btn" %>


### PR DESCRIPTION
Améliorations des prompts de l'IA :

- Le prompt de résumé précise qu’il s'agit de conversations entre deux personnes et demande à ne pas utiliser le nom de l’utilisateur dans le résumé.
- Le prompt de suggestion inclut les noms de l’utilisateur et du contact, la date du dernier message et la date d’aujourd’hui, en rappelant que du temps a pu passer.
- Le prompt de suggestion rekonect ajoute le nom de l’utilisateur, la date du dernier message et la date actuelle, en tenant compte du temps écoulé.

Changement dans le formulaire frontend :

- Le bouton d’envoi pour les réponses IA dans _ai_suggestion.html.erb désactive Turbo pour éviter des problèmes lors de la soumission.