### PR TITLE
front/ moins de texte, repositionnement des card, modif couleurs

### DIFF
--- a/app/assets/stylesheets/pages/_messages.scss
+++ b/app/assets/stylesheets/pages/_messages.scss
@@ -177,6 +177,20 @@ body {
   gap: 28px;
   margin: 18px 0 0 0;
 
+  .btn-modifier {
+    width: 90%;
+    max-width: 90vw;
+    height: 38px;
+    margin: 16px auto 0 auto;
+    background: white;
+    color: $pink-btn;
+    font-weight: 800;
+    font-size: 1.20rem;
+    border-radius: 50px;
+    border-color: $pink-btn;
+    text-decoration: none;
+  }
+
   > * {
     flex: 1 1 0;
     min-width: 0;
@@ -184,7 +198,6 @@ body {
     display: flex !important;
   }
 }
-
 // .reply-btn {
 //   width: 100% !important;
 //   min-width: 120px;

--- a/app/views/messages/_ai_suggestion.html.erb
+++ b/app/views/messages/_ai_suggestion.html.erb
@@ -10,7 +10,7 @@
       <%= f.submit "Envoyer", class: "btn btn-pink reply-btn", data: { turbo: false } %>
     <% end %>
 
-    <%= link_to "Modifier", edit_message_path(message), data: { turbo_frame: :message_suggestion }, class: "btn btn-pink reply-btn" %>
+    <%= link_to "Modifier", edit_message_path(message), data: { turbo_frame: :message_suggestion }, class: "btn-modifier btn-pink reply-btn" %>
 
   </div>
 <% end %>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag :message_suggestion do %>
   <div class="reply-block-title"><%= @message.sender_id == current_user.id ? "Modification de la relance à envoyer :" : "Modification de la réponse à envoyer :" %></div>
-    <div class="card-mobile msg-inner-bubble mb-0">
+    <div class="card-edit msg-inner-bubble mb-0">
       <%= simple_form_for Message.new do |f| %>
         <%= f.input :conversation_id, as: :hidden, input_html: { value: @conversation.id } %>
         <%= f.input :content, label: "Votre réponse", as: :text, input_html: { value: @message.ai_draft, rows: 5 } %>

--- a/app/views/messages/rekonect.html.erb
+++ b/app/views/messages/rekonect.html.erb
@@ -12,38 +12,37 @@
   </div>
 </div>
 
-<!-- Dernier message envoyé par l'utilisateur et resté sans réponse -->
-<div class="msg-bubble-pink mb-3">
-  <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('last-message-block', 'icon-last')">
-    <span>Dernier message de ta part</span>
-    <span id="icon-last">🔻</span> <!-- Flèche vers le bas -->
-  </div>
-  <div id="last-message-block" class="slide-toggle open">
-    <div class="card-mobile msg-inner-bubble mb-0">
-      <div class="message-content"><%= @message.content %></div>
-      <div class="message-date text-end">Il y a <%= time_ago_in_words(@message.created_at) %></div>
-    </div>
-  </div>
-</div>
-
 <!-- Historique -->
 <% if @summary.present? %>
   <div class="msg-bubble-pink mb-2">
     <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('history-messages-block', 'icon-history')">
       <div>
-        <%= @message.contact.name %> fait partie de votre entourage proche !<br>
         Voici un résumé de vos derniers échanges :
       </div>
       <span id="icon-history">🔻</span> <!-- Flèche vers le bas -->
     </div>
 
-    <div id="history-messages-block" class="slide-toggle open">
+    <div id="history-messages-block" class="slide-toggle non-open">
         <div class="card-mobile msg-inner-bubble mb-1">
           <div class="message-content"><%= @summary %></div>
         </div>
     </div>
   </div>
 <% end %>
+
+<!-- Dernier message envoyé par l'utilisateur et resté sans réponse -->
+<div class="msg-bubble-pink mb-3">
+  <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('last-message-block', 'icon-last')">
+    <span>Dernier message de ta part</span>
+    <span id="icon-last">🔻</span> <!-- Flèche vers le bas -->
+  </div>
+  <div id="last-message-block" class="slide-toggle non-open">
+    <div class="card-mobile msg-inner-bubble mb-0">
+      <div class="message-content"><%= @message.content %></div>
+      <div class="message-date text-end">Il y a <%= time_ago_in_words(@message.created_at) %></div>
+    </div>
+  </div>
+</div>
 
 <!-- Suggestion de réponse (toujours visible) -->
 <div class="msg-bubble-pink mb-3">

--- a/app/views/messages/reply.html.erb
+++ b/app/views/messages/reply.html.erb
@@ -15,6 +15,23 @@
   <% end %>
 </div>
 
+<!-- Historique -->
+<% if @summary.present? %>
+  <div class="msg-bubble-pink mb-2">
+    <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('history-messages-block', 'icon-history')">
+      <div>
+        Voici un résumé de vos derniers échanges :
+      </div>
+      <span id="icon-history">🔻</span>
+    </div>
+
+    <div id="history-messages-block" class="slide-toggle non-open">
+        <div class="card-mobile msg-inner-bubble mb-1">
+          <div class="message-content"><%= @summary %></div>
+        </div>
+    </div>
+  </div>
+<% end %>
 
 <!-- Dernier message non répondu -->
 <div class="msg-bubble-pink mb-3">
@@ -22,31 +39,13 @@
     <span>Dernier message non-répondu</span>
     <span id="icon-last">🔻</span>
   </div>
-  <div id="last-message-block" class="slide-toggle open">
+  <div id="last-message-block" class="slide-toggle non-open">
     <div class="card-mobile msg-inner-bubble mb-0">
       <div class="message-content"><%= @message.content %></div>
       <div class="message-date text-end">Il y a <%= time_ago_in_words(@message.created_at) %></div>
     </div>
   </div>
 </div>
-
-<% if @summary.present? %>
-  <div class="msg-bubble-pink mb-2">
-    <div class="reply-block-title d-flex justify-content-between align-items-center" onclick="toggleBlock('history-messages-block', 'icon-history')">
-      <div>
-        <%= @message.contact.name %> fait partie de votre entourage proche<br>
-        Voici un résumé de vos derniers échanges :
-      </div>
-      <span id="icon-history">🔻</span>
-    </div>
-
-    <div id="history-messages-block" class="slide-toggle open">
-        <div class="card-mobile msg-inner-bubble mb-1">
-          <div class="message-content"><%= @summary %></div>
-        </div>
-    </div>
-  </div>
-<% end %>
 
 <!-- Suggestion de réponse (toujours visible) -->
 <div class="msg-bubble-pink mb-3">


### PR DESCRIPTION
Travail majoritairement sur le front:
**Dashboard:** 
-Diminution de la taille du logo
-Suppression et remodelage de certaines phrases pour les rendre plus courtes
-Card principale déjà ouverte
-Agrandissement des cards de manière à ce qu'elles soient plus grandes en responsive
-Suppression de la card rose pour la section "et sinon?"

**Rekonect (réponse):**
-Retravail de l'ordre des cards de manière à les rendre plus logiques
-Modification du bouton "modifier" de manière à inverser les couleurs et contraster avec le bouton "envoyer"
-Les cards "dernier message envoyé" ainsi que l'historique des anciens messages sont désormais fermés de base

**Page d'acceuil**
-Il y a maintenant un peu moins de texte