### PR TITLE
fix:forcereload-and-add-xpbar-progress-inchat

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -43,18 +43,34 @@ class MessagesController < ApplicationController
     )
     authorize @message
     if @message.save
-      xp_context = Message.where(sender: current_user, contact_id: @conversation.contact_id).count == 0 ? :first_message : :rekonect
-      @xp_gained = current_user.add_contextual_xp(xp_context)
-      flash[:level_up] = true if current_user.leveled_up?
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.append(:messages, partial: "messages/message",
-            locals: { message: @message })
-        end
-        format.html { redirect_to conversation_path(@conversation) }
+    # 🔥 Ajout XP
+    xp_context = Message.where(sender: current_user, contact_id: @conversation.contact_id).count == 0 ? :first_message : :rekonect
+    @xp_gained = current_user.add_contextual_xp(xp_context)
+
+    flash[:level_up] = true if current_user.leveled_up?
+
+    respond_to do |format|
+      # ✅ TurboStream classique
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.append(:messages, partial: "messages/message", locals: { message: @message })
       end
-    else
-      render "conversations/show", status: :unprocessable_entity
+
+      # ✅ HTML fallback
+      format.html { redirect_to conversation_path(@conversation) }
+
+      # ✅ JSON pour Stimulus
+      format.json do
+        render json: {
+          xp_percent: current_user.xp_percent,
+          xp_progress: current_user.xp_progress,
+          xp_total: current_user.xp_for_next_level,
+          level: current_user.level,
+          level_up: flash[:level_up] == true
+        }
+      end
+    end
+  else
+    render "conversations/show", status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/controllers/reset_form_controller.js
+++ b/app/javascript/controllers/reset_form_controller.js
@@ -5,6 +5,6 @@ export default class extends Controller {
   reset() {
     // Reset le champ de saisie du formulaire
     this.element.reset()
-    window.location.reload()
+    /* window.location.reload() */
     }
 }

--- a/app/javascript/controllers/send_message_controller.js
+++ b/app/javascript/controllers/send_message_controller.js
@@ -1,39 +1,48 @@
-/* import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus"
 
+// Connects to data-controller="send-message"
 export default class extends Controller {
   static targets = ["form"]
 
   submit(event) {
     event.preventDefault()
+
     const url = this.formTarget.action
     const formData = new FormData(this.formTarget)
 
     fetch(url, {
       method: "POST",
-      headers: {
-        "Accept": "application/json",
-        "X-CSRF-Token": document.querySelector("[name='csrf-token']").content
-      },
+      headers: { Accept: "application/json" },
       body: formData
     })
       .then(response => response.json())
       .then(data => {
-  // Envoie un event personnalisé pour mettre à jour la barre d’XP
-  window.dispatchEvent(new CustomEvent("xp-gained", {
-    detail: { xp: data.xp_gained, level: data.level }
-  }))
+        // Reset le formulaire
+        this.formTarget.reset()
 
-  // Si le backend t’envoie une info de level-up
-  if (data.level_up === true) {
-    window.dispatchEvent(new CustomEvent("level-up"))
+        const fill = document.querySelector(".xp-bar-fill")
+        const progress = document.querySelector(".xp-bar-progress")
+        const level = document.querySelector(".xp-level-number")
+
+        if (fill) {
+          fill.dataset.xpPercent = data.xp_percent
+          fill.dataset.xpCurrent = data.xp_progress
+          fill.dataset.xpTotal = data.xp_total
+          fill.style.width = `${data.xp_percent}%`
+        }
+
+        if (progress) {
+          progress.innerText = `${data.xp_progress}/${data.xp_total} XP`
+        }
+
+        if (level) {
+          level.innerText = data.level
+        }
+
+        // 🎉 Animation LEVEL UP ?
+        if (data.level_up) {
+          window.dispatchEvent(new Event("level-up"))
+        }
+      })
   }
-
-  // Insère le nouveau message dans le DOM
-  const messagesContainer = document.getElementById("messages")
-  messagesContainer.insertAdjacentHTML("beforeend", data.html)
-
-  // Réinitialise le formulaire
-  this.formTarget.reset()
-  } )
-} }
- */
+}


### PR DESCRIPTION
Enlevé le force reload pour garder le dynamisme de turbo stream lors de l'envoi du message
le son est enfin joué lorsque la personne 

à fix : level up apparait deux fois