### PR TITLE
Changes in model messages

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -54,7 +54,7 @@ class MessagesController < ApplicationController
         format.html { redirect_to conversation_path(@conversation) }
       end
     else
-      render "conversations/show", status: :unprocessable_entity
+      redirect_to conversations_show_path(@conversation), status: :unprocessable_entity
     end
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,14 +6,10 @@ class Message < ApplicationRecord
   after_create_commit :broadcast_message
 
   # contenu taille min 1, max 2000
-  # conditions similaires pour la suggestion IA et la réponse utilisateur
+  # conditions similaires pour la suggestion IA
   # Allow blank est en true car aucun champ n'est obligatoire mais il faudra un des trois pour que le message soit créé
-  validates :content, length: { minimum: 1, maximum: 2000 }, allow_blank: true
+  validates :content, length: { minimum: 1, maximum: 2000 }, presence: true, allow_blank: false
   validates :ai_draft, length: { minimum: 1, maximum: 2000 }, allow_blank: true
-
-  # Validation perso pour être sûrs qu'au moins un champ entre content, ai_draft et user_answer soit rempli pour
-  # pouvoir créer un message
-  validate :content_or_ai_draft_or_user_answer_present
 
   # Date d’envoi optionnelle, pas dans le futur, peut être blanc
   # validates :sent_at, allow_blank: true, comparison: { less_than_or_equal_to: Date.today }
@@ -27,13 +23,6 @@ class Message < ApplicationRecord
   enum status: { sent: 0, draft_by_ai: 1 }
 
   private
-
-  # On vérifie qu'au moins un champ soit rempli sinon erreur
-  def content_or_ai_draft_or_user_answer_present
-    if [content, ai_draft].all?(&:blank?)
-      errors.add(:base, "Please provide content, an AI draft" )
-    end
-  end
 
   def broadcast_message
     broadcast_append_to "conversation_#{conversation.id}_messages",


### PR DESCRIPTION
- Le champ content est désormais obligatoire et ne peut plus être vide.
- La validation personnalisée qui permettait de créer un message avec seulement ai_draft a été supprimée : seul content est requis.
- 
Comportement du contrôleur modifié :
En cas d’échec lors de la création d’un message, le contrôleur redirige maintenant vers la page de la conversation avec un statut unprocessable entity, au lieu de rendre directement le template (ce qui provoquait une erreur 500 car la variable @messages était vide)
