### PR TITLE
fix(level-up):corrige le bug du level-up qui apparaissait plusieurs f…

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -47,25 +47,23 @@ class MessagesController < ApplicationController
     xp_context = Message.where(sender: current_user, contact_id: @conversation.contact_id).count == 0 ? :first_message : :rekonect
     @xp_gained = current_user.add_contextual_xp(xp_context)
 
-    flash[:level_up] = true if current_user.leveled_up?
+    @level_up = current_user.leveled_up?
 
     respond_to do |format|
-      # ✅ TurboStream classique
       format.turbo_stream do
         render turbo_stream: turbo_stream.append(:messages, partial: "messages/message", locals: { message: @message })
       end
 
-      # ✅ HTML fallback
       format.html { redirect_to conversation_path(@conversation) }
 
-      # ✅ JSON pour Stimulus
       format.json do
         render json: {
+          message_partial: render_to_string(partial: "messages/message", formats: [:html], locals: { message: @message }),
           xp_percent: current_user.xp_percent,
           xp_progress: current_user.xp_progress,
           xp_total: current_user.xp_for_next_level,
           level: current_user.level,
-          level_up: flash[:level_up] == true
+          level_up: @level_up
         }
       end
     end

--- a/app/javascript/controllers/level_up_controller.js
+++ b/app/javascript/controllers/level_up_controller.js
@@ -3,11 +3,16 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="level-up"
 export default class extends Controller {
   connect() {
-    window.addEventListener("level-up", this.show, { once: true })
+    if (window._levelUpListenerAdded) return;
+
+    this._onLevelUp = this.show.bind(this)
+    window.addEventListener("level-up", this._onLevelUp)
+    window._levelUpListenerAdded = true
   }
 
   disconnect() {
-    window.removeEventListener("level-up", this.show)
+    window.removeEventListener("level-up", this._onLevelUp)
+    window._levelUpListenerAdded = false
   }
 
   show() {


### PR DESCRIPTION
…ois même sans vrai level up : on utilise @level_up au lieu de flash[:level_up], on ajoute une sécurité window._levelUpListenerAdded pour éviter les doublons, on bind proprement l'event dans level_up_controller.js et on le retire quand on quitte la page. aussi, on ajoute message_partial dans le JSON pour afficher le message sans recharger