### PR TITLE
fix:(level-up):corrige bug popup level up après envoi de message + ga…

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -48,6 +48,7 @@ class MessagesController < ApplicationController
     @xp_gained = current_user.add_contextual_xp(xp_context)
 
     @level_up = current_user.leveled_up?
+    session[:level_up] = current_user.level if @level_up
 
     respond_to do |format|
       format.turbo_stream do
@@ -102,7 +103,7 @@ class MessagesController < ApplicationController
   def send_message
     if @message.update(user_answer: @message.ai_draft, status: :sent, sent_at: Date.current)
       current_user.add_contextual_xp(:ai_reply)
-      flash[:level_up] = true if current_user.leveled_up?
+      session[:level_up] = current_user.level if current_user.leveled_up?
       redirect_to success_messages_path, notice: "Bravo, tu t’es Rekonect avec succès ! 🚀"
     else
       redirect_to reply_message_path(@message), alert: "Erreur lors de l’envoi de la réponse."

--- a/app/javascript/controllers/level_up_controller.js
+++ b/app/javascript/controllers/level_up_controller.js
@@ -5,10 +5,19 @@ export default class extends Controller {
   connect() {
     if (window._levelUpListenerAdded) return;
 
-    this._onLevelUp = this.show.bind(this)
-    window.addEventListener("level-up", this._onLevelUp)
-    window._levelUpListenerAdded = true
+  this._onLevelUp = this.show.bind(this)
+  window.addEventListener("level-up", this._onLevelUp)
+  window._levelUpListenerAdded = true
+
+  const pendingLevelUp = document.getElementById("pending-levelup")
+  if (pendingLevelUp) {
+    const level = pendingLevelUp.dataset.level
+    if (window.lastLevelUp !== level) {
+      window.lastLevelUp = level
+      this.show()
+    }
   }
+}
 
   disconnect() {
     window.removeEventListener("level-up", this._onLevelUp)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,10 @@
   <%= render "shared/flashes" %>
   <%= render "shared/xp_bar" %>
   <div data-controller="badge-popup level-up"></div>
+  <% if session[:level_up] && current_user&.level == session[:level_up] %>
+  <div id="pending-levelup" data-level="<%= session[:level_up] %>"></div>
+  <% session.delete(:level_up) %>
+  <% end %>
   <%= render "shared/navbar_bottom" %>
   <%= yield %>
 </body>


### PR DESCRIPTION
utilise `session[:level_up]` au lieu de `flash[:level_up]` pour conserver l'info de level up après redirection
ajoute un `#pending-levelup` dans le layout pour détecter un level up lors du chargement de la page
update `level_up_controller.js` pour détecter ce niveau et empêcher les popups en double
évite les déclenchements intempestifs avec `window.lastLevelUp`