### PR TITLE
bouton envoyer grossi sur les vues rekonect et reply pour que le CTA soit clair

### DIFF
--- a/app/assets/stylesheets/pages/_messages.scss
+++ b/app/assets/stylesheets/pages/_messages.scss
@@ -192,28 +192,54 @@ body {
 .reply-btn-row {
   display: flex;
   justify-content: center;
-  gap: 28px;
+  align-items: center;
+  gap: 10px;
   margin: 18px 0 0 0;
+  width: 100%;
+
+  .reply-btn {
+    font-size: 17px !important; // Taille du texte plus grande pour "envoyer"
+    padding: 12px 0 !important; // Padding vertical important pour "envoyer"
+    box-shadow: 0 6px 16px $card-shadow;
+    margin-top: 20px !important;
+    letter-spacing: 0.6px;
+  }
+
+  form {
+    flex-grow: 1;
+    flex-basis: 0;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+
+    .btn-envoyer {
+      width: 100%; // Largeur maximale pour "envoyer"
+    }
+  }
 
   .btn-modifier {
-  width: 100%;
-  max-width: 400px;
-  padding: 0.8rem 1.5rem;
-  font-size: 1rem;
-  border-radius:50px;
-  background: white;
-  color: #ea6c80;
-  font-weight: bold;
-  border: none;
-  box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.1);
-  cursor: pointer;
-  text-decoration: none;
+    flex-shrink: 0; // ne rétrécit pas
+    font-size: 0.9rem !important;
+    width: auto;
+    max-width: 160px;
+    padding: 0.6rem 1.2rem !important;
+    background: white;
+    color: #ea6c80;
+    font-weight: bold;
+    border: none;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.08);
+    cursor: pointer;
+    text-decoration: none;
+    opacity: 0.8 !important;
+  }
+
+  .btn-modifier:hover {
+    opacity: 1;
+    color: white;
   }
 
   > * {
-    flex: 1 1 0;
     min-width: 0;
-    max-width: 170px;
     display: flex !important;
   }
 }

--- a/app/views/messages/_ai_suggestion.html.erb
+++ b/app/views/messages/_ai_suggestion.html.erb
@@ -7,7 +7,7 @@
     <%= simple_form_for Message.new do |f| %>
       <%= f.input :conversation_id, as: :hidden, input_html: { value: conversation.id } %>
       <%= f.input :content, as: :hidden, input_html: { value: message.ai_draft } %>
-      <%= f.submit "Envoyer", class: "btn btn-pink reply-btn", data: { turbo: false } %>
+      <%= f.submit "Envoyer", class: "btn btn-pink reply-btn btn-envoyer", data: { turbo: false } %>
     <% end %>
 
     <%= link_to "Modifier", edit_message_path(message), data: { turbo_frame: :message_suggestion }, class: "btn-modifier btn-pink reply-btn" %>


### PR DESCRIPTION
Cette pull request améliore l’ergonomie et la cohérence visuelle des boutons sur la page des messages :
- Meilleur agencement en flexbox : centrage vertical, espacement réduit, formulaire en pleine largeur.
- Boutons (reply-btn, btn-envoyer, btn-modifier) retravaillés : taille, padding, hiérarchie visuelle, effets au survol, ombres.
- Mise à jour du partial _ai_suggestion.html.erb pour appliquer les nouveaux styles au bouton "Envoyer".
<img width="437" height="927" alt="envoyer" src="https://github.com/user-attachments/assets/40d3bc7f-1c2d-40c4-b9b2-a46939824c7f" />
