### PR TITLE
Tentative de styliser champ edition

### DIFF
--- a/app/assets/stylesheets/pages/_messages.scss
+++ b/app/assets/stylesheets/pages/_messages.scss
@@ -67,6 +67,7 @@ body {
 .message-content {
   color: $gray-txt;
   font-size: 16px;
+
 }
 
 // header arrondi
@@ -181,6 +182,14 @@ body {
   font-weight: 700;
 }
 
+.edit-form-content {
+  overflow-y: auto; // Permet le défilement si le contenu est trop long
+}
+
+.edit-form-content:hover {
+    color: #222 !important;
+}
+
 .message-date {
   color: $gray-txt;
   font-size: 0.96rem;
@@ -243,22 +252,6 @@ body {
     display: flex !important;
   }
 }
-// .reply-btn {
-//   width: 100% !important;
-//   min-width: 120px;
-//   max-width: 170px;
-//   font-size: 1.19rem !important;
-//   border-radius: 18px !important;
-//   margin: 0;
-//   box-shadow: 0 4px 16px $card-shadow;
-//   font-weight: 700;
-//   padding: 12px 0 !important;
-//   transition: transform 0.13s;
-//   text-align: center;
-//   align-items: center;
-//   justify-content: center;
-//   display: flex !important;
-// }
 
 // bouton envoyer pour la view edit
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -43,33 +43,33 @@ class MessagesController < ApplicationController
     )
     authorize @message
     if @message.save
-    # 🔥 Ajout XP
-    xp_context = Message.where(sender: current_user, contact_id: @conversation.contact_id).count == 0 ? :first_message : :rekonect
-    @xp_gained = current_user.add_contextual_xp(xp_context)
+      # 🔥 Ajout XP
+      xp_context = Message.where(sender: current_user, contact_id: @conversation.contact_id).count == 0 ? :first_message : :rekonect
+      @xp_gained = current_user.add_contextual_xp(xp_context)
 
-    @level_up = current_user.leveled_up?
-    session[:level_up] = current_user.level if @level_up
+      @level_up = current_user.leveled_up?
+      session[:level_up] = current_user.level if @level_up
 
-    respond_to do |format|
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.append(:messages, partial: "messages/message", locals: { message: @message })
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.append(:messages, partial: "messages/message", locals: { message: @message })
+        end
+
+        format.html { redirect_to conversation_path(@conversation) }
+
+        format.json do
+          render json: {
+            message_partial: render_to_string(partial: "messages/message", formats: [:html], locals: { message: @message }),
+            xp_percent: current_user.xp_percent,
+            xp_progress: current_user.xp_progress,
+            xp_total: current_user.xp_for_next_level,
+            level: current_user.level,
+            level_up: @level_up
+          }
+        end
       end
-
-      format.html { redirect_to conversation_path(@conversation) }
-
-      format.json do
-        render json: {
-          message_partial: render_to_string(partial: "messages/message", formats: [:html], locals: { message: @message }),
-          xp_percent: current_user.xp_percent,
-          xp_progress: current_user.xp_progress,
-          xp_total: current_user.xp_for_next_level,
-          level: current_user.level,
-          level_up: @level_up
-        }
-      end
-    end
-  else
-    redirect_to conversations_show_path(@conversation), status: :unprocessable_entity
+    else
+      redirect_to conversations_show_path(@conversation), status: :unprocessable_entity
     end
   end
 

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -3,7 +3,7 @@
     <div class="msg-edit mb-0">
       <%= simple_form_for Message.new do |f| %>
         <%= f.input :conversation_id, as: :hidden, input_html: { value: @conversation.id } %>
-        <%= f.input :content, label: false, as: :text, input_html: { value: @message.ai_draft, rows: 5, class: "card-mobile msg-inner-bubble message-content edit-form-content"  } %>
+        <%= f.input :content, label: false, as: :text, input_html: { value: @message.ai_draft, rows: 5, class: "card-mobile msg-inner-bubble message-content edit-form-content" } %>
         <%= f.submit "Envoyer", class: "btn btn-pink reply-btn edit-form-btn", data: { turbo: false } %>
       <% end %>
     </div>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag :message_suggestion do %>
   <div class="reply-block-title"><%= @message.sender_id == current_user.id ? "Modification de la relance à envoyer :" : "Modification de la réponse à envoyer :" %></div>
-    <div class="card-edit msg-inner-bubble msg-edit mb-0">
+    <div class="msg-edit mb-0">
       <%= simple_form_for Message.new do |f| %>
         <%= f.input :conversation_id, as: :hidden, input_html: { value: @conversation.id } %>
-        <%= f.input :content, label: "Votre réponse", as: :text, input_html: { value: @message.ai_draft, rows: 5 } %>
+        <%= f.input :content, label: false, as: :text, input_html: { value: @message.ai_draft, rows: 5, class: "card-mobile msg-inner-bubble message-content edit-form-content"  } %>
         <%= f.submit "Envoyer", class: "btn btn-pink reply-btn edit-form-btn", data: { turbo: false } %>
       <% end %>
     </div>


### PR DESCRIPTION
- Ajout de la classe .edit-form-content pour permettre le scroll vertical sur les editions de message et conserver la couleur du texte au survol.
- Mise à jour du formulaire d’édition (edit.html.erb) avec les nouveaux styles pour une apparence cohérente et une meilleure gestion du contenu long.
- Nettoyage du CSS : suppression de styles commentés inutiles (.reply-btn).


https://github.com/user-attachments/assets/c27fbcdd-effe-4954-841e-d1c09920ee28

