### PR TITLE
tag cl_image_tag + seed modifiées

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -49,7 +49,7 @@
             <div class="quick-contact">
               <div class="contact-content">
                 <% if msg.contact.photo.attached? %>
-                  <%= image_tag msg.contact.photo, class: "avatar-mobile mb-1", alt: msg.contact.name %>
+                  <%= cl_image_tag msg.contact.photo.key, class: "avatar-mobile mb-1", alt: msg.contact.name %>
                 <% else %>
                   <%= image_tag "default-avatar.png", class: "avatar-mobile mb-1", alt: msg.contact.name %>
                 <% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -37,7 +37,7 @@
       <%= link_to conversation_path(conversation), class: "contact-card" do %>
         <div class="contact-avatar">
           <% if conversation.contact.photo.attached? %>
-            <%= image_tag conversation.contact.photo, class: "avatar-img" %>
+            <%= cl_image_tag conversation.contact.photo.key, class: "avatar-img" %>
           <% else %>
             <%= image_tag "default-avatar.png", class: "avatar-img" %>
           <% end %>

--- a/app/views/messages/rekonect.html.erb
+++ b/app/views/messages/rekonect.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="reply-avatar-block">
     <% if @message.contact.photo.attached? %>
-      <%= image_tag @message.contact.photo, class: "avatar-mobile ms-2" %>
+      <%= cl_image_tag @message.contact.photo.key, class: "avatar-mobile ms-2" %>
     <% else %>
       <%= image_tag "default-avatar.png", class: "avatar-mobile" %>
     <% end %>

--- a/app/views/messages/reply.html.erb
+++ b/app/views/messages/reply.html.erb
@@ -6,7 +6,7 @@
   <%= link_to message_path(@message.contact), class: "reply-card" do %>
     <div class="reply-avatar-block">
       <% if @message.contact.photo.attached? %>
-        <%= image_tag @message.contact.photo, class: "avatar-mobile ms-2" %>
+        <%= cl_image_tag @message.contact.photo.key, class: "avatar-mobile ms-2" %>
       <% else %>
         <%= image_tag "default-avatar.png", class: "avatar-img", alt: @message.contact.name %>
       <% end %>

--- a/app/views/shared/_xp_bar.html.erb
+++ b/app/views/shared/_xp_bar.html.erb
@@ -34,7 +34,7 @@
               data-infobulle-description-value="<%= badge.description %>"
               data-infobulle-condition-value="<%= badge.condition_description %>">
             <% if badge.image.attached? %>
-              <%= image_tag badge.image, class: "badge-icon", alt: badge.title %>
+              <%= cl_image_tag badge.image.key, class: "badge-icon", alt: badge.title %>
             <% else %>
               <%= image_tag "badge.png", class: "badge-icon", alt: badge.title %>
             <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -98,6 +98,7 @@ contact_infos.each_with_index do |info, idx|
     contact.photo.attach(io: File.open(Rails.root.join("app/assets/images/default-avatar.png")), filename: 'default-avatar.png', content_type: 'image/png')
     puts "Image par défaut attachée pour #{contact.name}"
   end
+  contact.save!
   puts "Contact créé : #{contact.name}, Image associée : #{contact.photo.attached? ? contact.photo.filename.to_s : 'Aucune'}"
 
   # création des conversations avec chaque contact
@@ -634,6 +635,7 @@ badges_infos.each do |info|
     badge.image.attach(io: File.open(Rails.root.join("app/assets/images/badge.png")), filename: 'badge.png', content_type: 'image/png')
     puts "Image par défaut attachée pour #{badge.title}."
   end
+  badge.save!
   puts "Badge #{badge.title} créé avec succès."
 end
 


### PR DESCRIPTION
- Mise à jour des vues (dashboard, messages, xp_bar) pour utiliser cl_image_tag sur les photos de contacts et les badges.
- Ajout de save! après l’attachement des images dans les seeds pour garantir leur enregistrement en base.
