### PR TITLE
feat(xp-popup): xp lvl up popup 100% fiable après AJAX et redirect

### DIFF
--- a/app/assets/stylesheets/components/_devise_card.scss
+++ b/app/assets/stylesheets/components/_devise_card.scss
@@ -91,10 +91,45 @@
   align-items: center;
 }
 
-.devise-links {
+.devise-link {
+  display: inline-block;
+  width: 100%;
+  margin: 26px 0 0 0;
+  padding: 0.72em 2.5em;
+  font-size: 1.13rem;
+  font-weight: 800;
+  border-radius: 23px;
+  background: $pink;
+  color: #fff !important;
+  box-shadow: 0 4px 20px 0px #e573a47e, 0 1.5px 7px #b5a5e8a0;
+  letter-spacing: 0.04em;
+  border: 2.5px solid #fff6;
   text-align: center;
-  display: flex;
-  flex-direction: column;
+  text-decoration: none;
+  position: relative;
+  z-index: 2;
+  filter: drop-shadow(0 6px 16px #e573a455);
+  transition:
+    background 0.15s,
+    box-shadow 0.13s,
+    border 0.17s,
+    transform 0.13s;
+
+  &:hover,
+  &:focus {
+    background: #b27ae8;
+    color: #fff !important;
+    border-color: #b27ae8;
+    transform: translateY(-2px) scale(1.035);
+    outline: none;
+    filter: brightness(1.07);
+    text-decoration: underline;
+  }
+
+  &:active {
+    transform: scale(0.97);
+    filter: brightness(0.97);
+  }
 }
 
 .devise-links a {

--- a/app/assets/stylesheets/components/_xp_bar.scss
+++ b/app/assets/stylesheets/components/_xp_bar.scss
@@ -105,3 +105,232 @@
   max-width: 200px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.2);
 }
+
+// modale xp flash
+
+.level-up-popup {
+  position: fixed;
+  top: 40%;
+  left: 38%;
+  transform: translate(-50%, -50%) scale(1);
+  z-index: 100002;
+  min-width: 210px;
+  max-width: 84vw;
+  padding: 1.1rem 1.4rem 1.5rem 1.4rem;
+  border-radius: 22px;
+  font-family: 'Work Sans', 'Poppins', sans-serif;
+  font-size: 1.29rem;
+  font-weight: 800;
+  color: #8a43ff;
+  background: linear-gradient(132deg, #fff9fc 60%, #e1d7ff 100%);
+  box-shadow: 0 6px 24px 0 #b967ff28, 0 1px 8px #fff4;
+  border: 1.3px solid #c7b3f5;
+  animation: levelUpPop 0.7s cubic-bezier(.23,1.1,.52,1.13), levelUpFade 2.5s 1.1s cubic-bezier(.62,0,.41,1) forwards;
+  pointer-events: none;
+  user-select: none;
+  text-align: center;
+  overflow: visible;
+  filter: drop-shadow(0 4px 12px #b967ff22);
+
+  .level-up-title {
+    font-size: 1.5rem;
+    margin: 0 0 0.17em 0;
+    color: #9f53fa;
+    letter-spacing: 0.04em;
+    text-shadow: 0 3px 18px #e1d7ff44, 0 1px 2px #fff6;
+    animation: popText 0.5s cubic-bezier(.45,1.7,.51,1.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 9px;
+
+    .level-badge {
+      background: linear-gradient(90deg, #b967ff 0%, #8fd3f4 100%);
+      color: #fff;
+      font-size: 1.03em;
+      font-weight: 900;
+      border-radius: 12px;
+      padding: 4px 15px;
+      margin-left: 7px;
+      box-shadow: 0 1px 5px #b967ff1e;
+      animation: shakeBadge 1s cubic-bezier(.18,.88,.55,1.01) infinite;
+      letter-spacing: 0.04em;
+      border: none;
+      display: inline-flex;
+      align-items: center;
+    }
+  }
+  .level-up-message {
+    font-size: 1.01rem;
+    color: #6742aa;
+    font-weight: 600;
+    margin: 1em 0 0 0;
+    letter-spacing: 0.01em;
+    animation: pulseText 1.3s 1 cubic-bezier(.28,.71,.68,1.31) infinite alternate;
+  }
+
+  // confettis et felicitations
+  .confettis {
+    pointer-events: none;
+    position: absolute;
+    left: 50%; top: -20px;
+    width: 96px; height: 34px;
+    transform: translateX(-50%);
+    z-index: 1;
+  }
+  .confettis::before,
+  .confettis::after {
+    content: "🎉🎊✨";
+    font-size: 0.98rem;
+    display: block;
+    animation: confettiFall 0.22s ease-out forwards;
+  }
+}
+
+// animation au opp
+@keyframes levelUpPop {
+  0%   { transform: translate(-50%, -50%) scale(0.85); opacity: 0; }
+  55%  { transform: translate(-50%, -50%) scale(1.15); opacity: 1; }
+  80%  { transform: translate(-50%, -50%) scale(0.98);}
+  100% { transform: translate(-50%, -50%) scale(1.02);}
+}
+
+@keyframes levelUpFade {
+  0%,70% { opacity: 1; }
+  100%   { opacity: 0; }
+}
+
+@keyframes popText {
+  0% { transform: scale(0.7) translateY(12px);}
+  60% { transform: scale(1.15) translateY(-6px);}
+  100% { transform: scale(1) translateY(0);}
+}
+
+@keyframes shakeBadge {
+  0%,100% { transform: rotate(-6deg) scale(0.97);}
+  30%     { transform: rotate(8deg) scale(1.09);}
+  70%     { transform: rotate(-3deg) scale(1);}
+}
+
+@keyframes pulseText {
+  0% { text-shadow: 0 1px 6px #fbc2eb99;}
+  100% { text-shadow: 0 2px 14px #b967ff55;}
+}
+
+@keyframes confettiFall {
+  from { transform: translateY(-36px) scale(1.18) rotate(-16deg);}
+  to   { transform: translateY(30px) scale(1) rotate(8deg);}
+}
+
+
+// modale xp gain bar
+
+.xp-bar-popup-line {
+  position: fixed;
+  bottom: 66px; // ajuster ici pour la position
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100001;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 90vw;
+  max-width: 400px;
+  padding: 8px 0;
+  animation: fadeInXP 0.4s ease-out;
+  pointer-events: none;
+}
+
+.xp-bar-popup-line .xp-bar {
+  width: 200px;
+  height: 12px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: rgba(255,255,255,0.5);
+  backdrop-filter: blur(3px);
+  position: relative;
+  border: 1px solid #e5dbff;
+}
+
+.xp-bar-popup-line .xp-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #b967ff 10%, #8fd3f4 80%);
+  background-size: 160% 160%;
+  animation: xpNeonPopup 2.5s ease-in-out infinite;
+  border-radius: 8px;
+  transition: width 0.5s cubic-bezier(0.16,1,0.3,1);
+  position: relative;
+}
+
+.xp-bar-popup-line .xp-bar-fill .xp-progress-badge {
+  position: absolute;
+  top: 50%;
+  right: -0.6em;
+  transform: translateY(-50%);
+  font-size: 1.15em;
+  pointer-events: none;
+  z-index: 2;
+  transition: right 0.5s cubic-bezier(0.16,1,0.3,1);
+  user-select: none;
+}
+
+// texte xp dans la pop up
+.xp-bar-popup-line .xp-bar-popup-text {
+  display: flex;
+  justify-content: space-between;
+  width: 200px;
+  font-size: 1.08em;
+  font-weight: 800;
+  color: #5c258d;
+  font-family: 'Work Sans', sans-serif;
+  letter-spacing: 0.03em;
+  margin: 0 0 0 2px;
+  flex: none;
+  line-height: 1.12;
+}
+
+.xp-bar-popup-line .xp-bar-progress {
+  color: #5c258d;
+  font-size: 1em;
+  font-weight: 800;
+}
+
+.xp-bar-popup-line .xp-level-number {
+  color: #b967ff;
+  font-size: 1.04em;
+  font-weight: 900;
+  margin-left: 10px;
+  letter-spacing: 0.04em;
+  border-radius: 14px;
+  padding: 2px 10px 2px 8px;
+  background: linear-gradient(90deg, #e6d2f5 0%, #e1f4fd 100%);
+  box-shadow: 0 1px 5px #b967ff17;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+// annimation
+@keyframes fadeInXP {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -60%);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+@keyframes xpNeonPopup {
+  0%,100% { background-position: 0% 50%; }
+  50%     { background-position: 100% 50%; }
+}
+
+// pour les tous petits tel
+@media (max-width: 500px) {
+  .xp-bar-popup-line { max-width: 99vw; }
+  .xp-bar-popup-line .xp-bar,
+  .xp-bar-popup-line .xp-bar-popup-text { width: 90vw; min-width: 80px; max-width: 99vw;}
+}

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -36,6 +36,9 @@ class ConversationsController < ApplicationController
     authorize @conversation
     @messages = @conversation.messages.order(created_at: :asc)
     @conversations = policy_scope(Conversation)
+
+    @pending_levelup = session.delete(:level_up)
+    @pending_xp_popup = session.delete(:xp_popup)
   end
 
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -50,6 +50,13 @@ class MessagesController < ApplicationController
       @level_up = current_user.leveled_up?
       session[:level_up] = current_user.level if @level_up
 
+      session[:xp_popup] = {
+      xp_percent: current_user.xp_percent,
+      xp_progress: current_user.xp_progress,
+      xp_total: current_user.xp_for_next_level,
+      level: current_user.level
+      }
+
       respond_to do |format|
         format.turbo_stream do
           render turbo_stream: turbo_stream.append(:messages, partial: "messages/message", locals: { message: @message })
@@ -94,6 +101,14 @@ class MessagesController < ApplicationController
 
   def update
     if @message.update(user_answer: params[:message][:user_answer], status: :sent, sent_at: Time.current)
+      current_user.add_contextual_xp(:reply)
+       session[:xp_popup] = {
+         xp_percent: current_user.xp_percent,
+         xp_progress: current_user.xp_progress,
+         xp_total: current_user.xp_for_next_level,
+         level: current_user.level
+       }
+       session[:level_up] = current_user.level if current_user.leveled_up?
       redirect_to success_messages_path, notice: "Bravo, tu t’es Rekonect avec succès ! 🚀"
     else
       render :edit, status: :unprocessable_entity
@@ -104,6 +119,12 @@ class MessagesController < ApplicationController
     if @message.update(user_answer: @message.ai_draft, status: :sent, sent_at: Date.current)
       current_user.add_contextual_xp(:ai_reply)
       session[:level_up] = current_user.level if current_user.leveled_up?
+      session[:xp_popup] = {
+      xp_percent: current_user.xp_percent,
+      xp_progress: current_user.xp_progress,
+      xp_total: current_user.xp_for_next_level,
+      level: current_user.level
+    }
       redirect_to success_messages_path, notice: "Bravo, tu t’es Rekonect avec succès ! 🚀"
     else
       redirect_to reply_message_path(@message), alert: "Erreur lors de l’envoi de la réponse."

--- a/app/javascript/controllers/badge_popup_controller.js
+++ b/app/javascript/controllers/badge_popup_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
       <div class="badge-title">🏅 ${title}</div>
     `
     document.querySelector("#notifications-container").appendChild(popup)
-    
-    setTimeout(() => popup.remove(), 4000)
+
+    setTimeout(() => popup.remove(), 20000)
   }
 }

--- a/app/javascript/controllers/level_up_controller.js
+++ b/app/javascript/controllers/level_up_controller.js
@@ -5,34 +5,48 @@ export default class extends Controller {
   connect() {
     if (window._levelUpListenerAdded) return;
 
-  this._onLevelUp = this.show.bind(this)
-  window.addEventListener("level-up", this._onLevelUp)
-  window._levelUpListenerAdded = true
+    this._onLevelUp = this.show.bind(this)
+    window.addEventListener("level-up", this._onLevelUp)
+    window._levelUpListenerAdded = true
 
-  const pendingLevelUp = document.getElementById("pending-levelup")
-  if (pendingLevelUp) {
-    const level = pendingLevelUp.dataset.level
-    if (window.lastLevelUp !== level) {
-      window.lastLevelUp = level
-      this.show()
+    // affiche au refresh si on a déjà un lvl up en attente
+    const pendingLevelUp = document.getElementById("pending-levelup")
+    if (pendingLevelUp) {
+      const level = pendingLevelUp.dataset.level
+      if (window.lastLevelUp !== level) {
+        window.lastLevelUp = level
+        this.show({ detail: { level } }) // asse le niveau directement
+      }
     }
   }
-}
 
   disconnect() {
     window.removeEventListener("level-up", this._onLevelUp)
     window._levelUpListenerAdded = false
   }
 
-  show() {
-    const box = document.createElement("div")
-    box.classList.add("level-up-popup")
-    box.innerHTML = "<h2>🎉 LEVEL UP !</h2>"
-    document.body.appendChild(box)
+  show(event) {
+  // supprime d'abord modale fantome
+    document.querySelectorAll('.level-up-popup').forEach(e => e.remove());
+    // condition pour recuperer l'event ou nul si absent
+    let level = event && event.detail && event.detail.level ? event.detail.level : null;
+    // injecte le html
+    const box = document.createElement("div");
+    box.classList.add("level-up-popup");
+    box.innerHTML = `
+      <h2 class="level-up-title">
+        🎉 LEVEL UP !
+        ${level ? `<span class="level-badge">LVL ${level}</span>` : ""}
+      </h2>
+      <p class="level-up-message">Bravo pour ta progression 🌱</p>
+      <div class="confettis"></div>
+    `;
+    document.body.appendChild(box);
 
-    const audio = new Audio("/sounds/xp-gain.mp3")
-    audio.play()
+    // Son
+    const audio = new Audio("/sounds/xp-gain.mp3");
+    audio.play();
 
-    setTimeout(() => box.remove(), 3000)
+    setTimeout(() => box.remove(), 3500);
   }
 }

--- a/app/javascript/controllers/send_message_controller.js
+++ b/app/javascript/controllers/send_message_controller.js
@@ -45,10 +45,21 @@ export default class extends Controller {
         if (level) {
           level.innerText = data.level
         }
-        
+
         if (data.level_up) {
-          window.dispatchEvent(new Event("level-up"))
+          window.dispatchEvent(new CustomEvent("level-up", { detail: { level: data.level } }))
         }
+
+        if (data.xp_percent !== undefined) {
+        window.dispatchEvent(new CustomEvent("xp-gain", {
+          detail: {
+            xpPercent: data.xp_percent,
+            xpCurrent: data.xp_progress,
+            xpTotal: data.xp_total,
+            level: data.level
+          }
+        }))
+      }
       })
       .catch(error => {
         console.error("Erreur envoi message", error)

--- a/app/javascript/controllers/sound_controller.js
+++ b/app/javascript/controllers/sound_controller.js
@@ -1,9 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-// Connects to data-controller="sound"
-export default class extends Controller {
-  play(soundPath) {
-    const audio = new Audio(soundPath)
-    audio.play()
-  }
-}

--- a/app/javascript/controllers/xp_bar_popup_controller.js
+++ b/app/javascript/controllers/xp_bar_popup_controller.js
@@ -4,7 +4,18 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     window.addEventListener("xp-gain", this.show.bind(this))
+    // si jamais on arrive d'un redirect et qu'il y a un gain XP à afficher, on le pop direct
+    const pending = document.getElementById("pending-xp-popup");
+    if (pending) {
+      const xpPercent = pending.dataset.xpPercent;
+      const xpCurrent = pending.dataset.xpProgress;
+      const xpTotal = pending.dataset.xpTotal;
+      const level = pending.dataset.level;
+      this.show({ detail: { xpPercent, xpCurrent, xpTotal, level } });
+      setTimeout(() => pending.remove(), 100); // clean le DOM après affichage
   }
+ }
+
 
   disconnect() {
     window.removeEventListener("xp-gain", this.show.bind(this))

--- a/app/javascript/controllers/xp_bar_popup_controller.js
+++ b/app/javascript/controllers/xp_bar_popup_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="xp-bar-popup"
+export default class extends Controller {
+  connect() {
+    window.addEventListener("xp-gain", this.show.bind(this))
+  }
+
+  disconnect() {
+    window.removeEventListener("xp-gain", this.show.bind(this))
+  }
+
+  show(event) {
+    // efface la modale fantome xp gain avant d'en rajouter une
+    document.querySelectorAll('.xp-bar-popup-container').forEach(el => el.remove());
+
+    const template = document.getElementById("xp-bar-popup-template")
+    if (!template) return
+
+    const clone = template.content.cloneNode(true)
+    const popup = document.createElement("div")
+    popup.classList.add("xp-bar-popup-container")
+    popup.appendChild(clone)
+
+    // event dy namique
+    if (event && event.detail) {
+      const { xpPercent, xpCurrent, xpTotal, level } = event.detail
+      const fill = popup.querySelector('.xp-bar-fill')
+      if (fill) {
+        fill.dataset.xpPercent = xpPercent
+        fill.dataset.xpCurrent = xpCurrent
+        fill.dataset.xpTotal = xpTotal
+        setTimeout(() => {
+          fill.style.width = `${xpPercent}%`
+        }, 30)
+      }
+      const progress = popup.querySelector('.xp-bar-progress')
+      if (progress) progress.textContent = `${xpCurrent}/${xpTotal} XP`
+      const levelText = popup.querySelector('.xp-level-number')
+      if (levelText) levelText.textContent = `LVL ${level}`
+    }
+     // remove auto
+    document.body.appendChild(popup)
+    setTimeout(() => popup.remove(), 3000)
+  }
+}

--- a/app/javascript/controllers/xp_notice_controller.js
+++ b/app/javascript/controllers/xp_notice_controller.js
@@ -24,6 +24,6 @@ export default class extends Controller {
 
   setTimeout(() => {
     box.remove()
-  }, 3000)
+  }, 20000)
  }
 }

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -1,4 +1,14 @@
 <div class="chat-container">
+  <% if @pending_levelup %>
+  <div id="pending-levelup" data-level="<%= @pending_levelup %>"></div>
+  <% end %>
+  <% if @pending_xp_popup %>
+  <div id="pending-xp-popup"
+       data-xp-percent="<%= @pending_xp_popup['xp_percent'] %>"
+       data-xp-progress="<%= @pending_xp_popup['xp_progress'] %>"
+       data-xp-total="<%= @pending_xp_popup['xp_total'] %>"
+       data-level="<%= @pending_xp_popup['level'] %>"></div>
+  <% end %>
   <h2 class="conversation-header">Conversation avec <strong><%= @conversation.contact.name %></strong></h2>
   <hr>
   <%= turbo_stream_from "conversation_#{@conversation.id}_messages" %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -11,6 +11,9 @@
     </div>
   </div>
 
+ <%= render "shared/xp_bar" %>
+
+
 <% main_msg = @main_message || Message.where("(sender_id = :id OR receiver_id = :id) AND status = :status AND (dismissed = false OR dismissed IS NULL)", id: current_user.id, status: Message.statuses[:received]).last %>
 <% if main_msg %>
   <div class="main-message-card">

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "🔓 Se connecter", new_session_path(resource_name), class: "devise-link-muted" %><br />
+  <%= link_to "🔓 Se connecter", new_session_path(resource_name), class: "devise-link" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,15 +44,6 @@
 
   <div data-controller="badge-popup level-up"></div>
 
-  <% if session[:level_up] && current_user&.level == session[:level_up] %>
-  <div id="pending-levelup"
-       data-level="<%= session[:level_up] %>"
-       style="display: none;"></div>
-  <% session.delete(:level_up) %>
-<% end %>
-
-<%# <div data-controller="badge-popup level-up"></div> %>
-
   <%= render "shared/navbar_bottom" %>
   <%= yield %>
 </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,12 +36,23 @@
   <%# ajout d'une classe personnalisée dans le body pour ne pas casser le body général quand on veut toucher à celui d'une page %>
   <body data-current-user-id="<%= current_user ? current_user.id : "" %>" class="<%= controller_name %>-<%= action_name %>">
   <%= render "shared/flashes" %>
-  <%= render "shared/xp_bar" %>
+  <div data-controller="xp-bar-popup"></div>
+
+  <template id="xp-bar-popup-template">
+    <%= render "shared/xp_bar_only" %>
+  </template>
+
   <div data-controller="badge-popup level-up"></div>
-    <% if session[:level_up] && current_user&.level == session[:level_up] %>
-      <div id="pending-levelup" data-level="<%= session[:level_up] %>"></div>
-    <% session.delete(:level_up) %>
-  <% end %>
+
+  <% if session[:level_up] && current_user&.level == session[:level_up] %>
+  <div id="pending-levelup"
+       data-level="<%= session[:level_up] %>"
+       style="display: none;"></div>
+  <% session.delete(:level_up) %>
+<% end %>
+
+<%# <div data-controller="badge-popup level-up"></div> %>
+
   <%= render "shared/navbar_bottom" %>
   <%= yield %>
 </body>

--- a/app/views/shared/_xp_bar_only.html.erb
+++ b/app/views/shared/_xp_bar_only.html.erb
@@ -1,0 +1,24 @@
+<% if current_user %>
+  <div class="xp-bar-popup-line" data-controller="xp-bar">
+    <div class="xp-bar">
+      <div
+        class="xp-bar-fill"
+        data-xp-bar-target="fill"
+        data-xp-percent="<%= current_user.xp_percent %>"
+        data-xp-current="<%= current_user.xp_progress %>"
+        data-xp-total="<%= current_user.xp_for_next_level %>"
+        style="width: <%= current_user.xp_percent %>%; position: relative;"
+      >
+        <span class="xp-progress-badge">🌟</span>
+      </div>
+    </div>
+    <div class="xp-bar-popup-text">
+      <span class="xp-bar-progress" data-xp-bar-target="progress">
+        <%= current_user.xp_progress %>/<%= current_user.xp_for_next_level %> XP
+      </span>
+      <span class="xp-level-number">
+        LVL <%= current_user.level %>
+      </span>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
refacto de la gestion des popups xp et level up
désormais, l’affichage des popups xp/level up est déclenché dynamiquement via stimulus js aussi bien après envoi ajax que sur redirection (submit classique)

stockage temporaire du gain d’xp et level up dans la session rails lors de l’envoi d’un message (create, update, send_message)

lecture et suppression des infos session dans la vue cible (conversations#show) pour affichage immédiat de la barre popup à l’arrivée sur la page

ajout d’un bloc <div id="pending-xp-popup" ...> dans conversations/show.html.erb pour permettre le déclenchement automatique de la popup via stimulus

correction du contrôleur stimulus xp_bar_popup_controller pour lire l’info d’un éventuel xp pending sur arrivée page (redirect), en plus du trigger classique via event js

suppression de tout affichage global dans layout/application.html.erb (plus de popups fantômes aléatoires)

ux : popup xp et level up cohérentes et 100% contextuelles, plus aucun bug ou affichage intempestif

plus aucun affichage de popup xp/level up ailleurs que sur la vue cible

(nécessite d’ajouter le bloc pending-xp-popup sur chaque nouvelle vue devant supporter la popup après redirect)