### PR TITLE
le xp-container n'est plus sticky

### DIFF
--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -71,15 +71,6 @@ body {
 
 // section barre xp
 
-.sticky-xp {
-  position: sticky;
-  top: 0;
-  z-index: 999;
-  background-color: #f5fbe8;
-  padding-top: 10px;
-  padding-bottom: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
-}
 .xp-bar-container {
   border: 2px solid white;
   border-radius: 35px;
@@ -91,6 +82,7 @@ body {
   width: 90%;
   max-width: 98vw;
   margin: 0px auto 20px auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
 }
 
 .xp-bar-logo {

--- a/app/views/shared/_xp_bar.html.erb
+++ b/app/views/shared/_xp_bar.html.erb
@@ -1,5 +1,5 @@
 <% if current_user %>
-  <div class="xp-bar-container sticky-xp"
+  <div class="xp-bar-container"
       data-controller="xp-bar level-up"
       data-level-up-level-up-value="<%= flash[:level_up] == true %>">
 


### PR DESCRIPTION
- Suppression de la classe .sticky-xp ainsi que de ses propriétés de positionnement et de style dans la feuille de style (_dashboard.scss) et le partial de la barre d’XP (_xp_bar.html.erb).
- Ajout de la propriété box-shadow directement à .xp-bar-container pour conserver l’effet visuel précédemment assuré par .sticky-xp
